### PR TITLE
Replace magic-number height offset with CSS flex layout

### DIFF
--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -127,8 +127,8 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
   const isParsed = !!parseResult && !rewriteResult;
   const isWorkshopping = !!rewriteResult;
 
-  // Height for the two-pane layout: account for header + tabs + mobile pane toggle
-  const splitHeight = 'h-[calc(100dvh-11rem)] md:h-[calc(100dvh-7rem)]';
+  // Whether the two-pane layout should fill the remaining viewport height
+  const fillHeight = isParsed || isWorkshopping;
 
   const handleParse = async () => {
     const trimmedInput = input.trim();
@@ -412,7 +412,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
   );
 
   return (
-    <div>
+    <div className={cn(fillHeight && 'flex-1 min-h-0 flex flex-col')}>
       {error && (
         <Alert variant="error" className="mt-4 mb-4">
           <span>{error}</span>
@@ -488,11 +488,11 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
 
       {/* PARSED state */}
       {isParsed && (
-        <div className="mt-2">
+        <div className="flex flex-col flex-1 min-h-0 mt-2">
           {mobilePaneToggle}
 
           <ResizableColumns
-            className={splitHeight}
+            className="flex-1 min-h-0"
             columnClassName="flex-col min-h-0"
             mobilePane={mobilePane === 'chat' ? 'left' : 'right'}
             left={
@@ -550,11 +550,11 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
 
       {/* WORKSHOPPING state */}
       {isWorkshopping && (
-        <div className="mt-2">
+        <div className="flex flex-col flex-1 min-h-0 mt-2">
           {mobilePaneToggle}
 
           <ResizableColumns
-            className={splitHeight}
+            className="flex-1 min-h-0"
             columnClassName="flex-col min-h-0"
             mobilePane={mobilePane === 'chat' ? 'left' : 'right'}
             left={

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -241,7 +241,7 @@ export default function AppShell() {
   };
 
   return (
-    <>
+    <div className="flex flex-col h-dvh">
       <Header
         user={currentAuthUser}
         authRequired={authConfig?.required ?? false}
@@ -249,10 +249,10 @@ export default function AppShell() {
         isPremium={isPremium}
       />
       <Tabs />
-      <main className="max-w-[1800px] mx-auto px-2 sm:px-4 py-4">
+      <main className="flex-1 min-h-0 flex flex-col overflow-auto max-w-[1800px] w-full mx-auto px-2 sm:px-4 py-4">
         <Outlet context={ctx} />
       </main>
       <Toaster position="bottom-right" richColors />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Restructured `AppShell` to use a `flex flex-col h-dvh` wrapper so `<main>` fills remaining viewport height via `flex-1 min-h-0`
- Removed the hardcoded `splitHeight = 'h-[calc(100dvh-11rem)] md:h-[calc(100dvh-7rem)]'` from `RewriteTab`
- Workshop and parsed two-pane states now use `flex-1 min-h-0` to fill available space naturally
- Library and Settings views continue to scroll normally within `overflow-auto` on `<main>`

Fixes #9

## Test plan

- [x] Verified 0px overflow on desktop (was 22px before) via Playwright measurement
- [x] Viewport and full-page screenshots are identical in workshop mode — no scroll needed
- [x] Library view renders correctly with normal scrolling
- [x] Input view works correctly
- [x] Added 2 unit tests: flex layout applied in workshop mode, not applied in input mode
- [x] All 54 frontend tests pass
- [x] TypeScript type check passes
- [x] ESLint clean
- [x] All 101 backend tests pass
- [x] Ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)