### PR TITLE
Make header and tabs sticky at top of viewport

### DIFF
--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -1,0 +1,50 @@
+import { screen } from '@testing-library/react';
+import { renderWithRouter } from '@/test/test-utils';
+
+vi.mock('@/api', () => ({
+  default: {
+    listProfiles: vi.fn().mockResolvedValue([]),
+  },
+  STORAGE_KEYS: {
+    PROVIDER: 'test_provider',
+    MODEL: 'test_model',
+    REASONING_EFFORT: 'test_effort',
+    CURRENT_SONG_ID: 'test_song_id',
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    authState: 'ready',
+    currentAuthUser: null,
+    authConfig: { required: false },
+    isPremium: false,
+    handleLogout: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useProviderConnections', () => ({
+  default: () => ({ connections: [], addConnection: vi.fn(), removeConnection: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useSavedModels', () => ({
+  default: () => ({ savedModels: [], addModel: vi.fn(), removeModel: vi.fn(), refresh: vi.fn() }),
+}));
+
+import AppShell from '@/layouts/AppShell';
+
+describe('AppShell layout', () => {
+  it('renders header and tabs inside a sticky wrapper', () => {
+    renderWithRouter(<AppShell />, { route: '/app/rewrite' });
+
+    const header = screen.getByRole('banner');
+    const stickyWrapper = header.parentElement!;
+    expect(stickyWrapper.className).toContain('sticky');
+    expect(stickyWrapper.className).toContain('top-0');
+
+    // Tabs are also inside the same sticky wrapper
+    expect(stickyWrapper).toContainElement(screen.getByText('Rewrite'));
+    expect(stickyWrapper).toContainElement(screen.getByText('Library'));
+    expect(stickyWrapper).toContainElement(screen.getByText('Settings'));
+  });
+});

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -242,13 +242,15 @@ export default function AppShell() {
 
   return (
     <>
-      <Header
-        user={currentAuthUser}
-        authRequired={authConfig?.required ?? false}
-        onLogout={handleLogout}
-        isPremium={isPremium}
-      />
-      <Tabs />
+      <div className="sticky top-0 z-40">
+        <Header
+          user={currentAuthUser}
+          authRequired={authConfig?.required ?? false}
+          onLogout={handleLogout}
+          isPremium={isPremium}
+        />
+        <Tabs />
+      </div>
       <main className="max-w-[1800px] mx-auto px-2 sm:px-4 py-4">
         <Outlet context={ctx} />
       </main>


### PR DESCRIPTION
## Summary

- Wrap `<Header>` and `<Tabs>` in a `sticky top-0 z-40` container div in `AppShell.tsx` so they remain pinned to the top of the viewport on scroll
- Add `AppShell.test.tsx` verifying the sticky wrapper contains both header and tabs

Fixes #8

## Test plan

- [x] New unit test verifies header and tabs are inside a sticky wrapper
- [ ] Manually scroll a page with body overflow — header and tabs stay visible
- [ ] Verify `splitHeight` calculation in `RewriteTab` still sizes panes correctly (sticky doesn't change document flow)
- [x] All frontend tests pass (53/53)
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] Backend tests pass (101/101)
- [x] Ruff lint + format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)