### PR TITLE
Make header and tabs sticky so they stay visible on scroll

### DIFF
--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -1,0 +1,62 @@
+import { screen } from '@testing-library/react';
+import { renderWithRouter } from '@/test/test-utils';
+
+// Mock auth context — ready state with no auth required
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    authState: 'ready',
+    currentAuthUser: null,
+    authConfig: { required: false },
+    isPremium: false,
+    handleLogout: vi.fn(),
+  }),
+}));
+
+// Mock api module
+vi.mock('@/api', () => ({
+  default: {
+    listProfiles: vi.fn().mockResolvedValue([{ id: 1, is_default: true }]),
+  },
+  STORAGE_KEYS: {
+    PROVIDER: 'test_provider',
+    MODEL: 'test_model',
+    REASONING_EFFORT: 'test_effort',
+    CURRENT_SONG_ID: 'test_song_id',
+  },
+}));
+
+// Mock hooks that call the backend
+vi.mock('@/hooks/useProviderConnections', () => ({
+  default: () => ({ connections: [], addConnection: vi.fn(), removeConnection: vi.fn() }),
+}));
+vi.mock('@/hooks/useSavedModels', () => ({
+  default: () => ({ savedModels: [], addModel: vi.fn(), removeModel: vi.fn(), refresh: vi.fn() }),
+}));
+
+// Stub heavy children so the test focuses on layout structure
+vi.mock('@/components/Header', () => ({
+  default: () => <div data-testid="header">Header</div>,
+}));
+vi.mock('@/components/Tabs', () => ({
+  default: () => <div data-testid="tabs">Tabs</div>,
+}));
+
+import AppShell from '@/layouts/AppShell';
+
+describe('AppShell layout', () => {
+  it('wraps header and tabs in a sticky container', () => {
+    renderWithRouter(<AppShell />, { route: '/app/rewrite' });
+
+    const header = screen.getByTestId('header');
+    const tabs = screen.getByTestId('tabs');
+
+    // Header and tabs should share the same parent wrapper
+    const wrapper = header.parentElement!;
+    expect(wrapper).toBe(tabs.parentElement);
+
+    // The wrapper must be sticky and positioned at top
+    expect(wrapper.className).toContain('sticky');
+    expect(wrapper.className).toContain('top-0');
+    expect(wrapper.className).toContain('z-50');
+  });
+});

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -242,13 +242,15 @@ export default function AppShell() {
 
   return (
     <div className="flex flex-col h-dvh">
-      <Header
-        user={currentAuthUser}
-        authRequired={authConfig?.required ?? false}
-        onLogout={handleLogout}
-        isPremium={isPremium}
-      />
-      <Tabs />
+      <div className="sticky top-0 z-50 shrink-0">
+        <Header
+          user={currentAuthUser}
+          authRequired={authConfig?.required ?? false}
+          onLogout={handleLogout}
+          isPremium={isPremium}
+        />
+        <Tabs />
+      </div>
       <main className="flex-1 min-h-0 flex flex-col overflow-y-auto max-w-[1800px] w-full mx-auto px-2 sm:px-4 py-4">
         <Outlet context={ctx} />
       </main>


### PR DESCRIPTION
## Description

The `<Header>` and `<Tabs>` in `AppShell.tsx` are plain block-flow elements with no sticky positioning. When the page has any body scroll (currently 22px in the workshop view), scrolling hides the navigation bar. This wraps them in a `sticky top-0 z-50 shrink-0` container so they remain pinned to the top of the viewport.

Fixes #8

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

**Any Additional AI Details you'd like to share:**

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)