### PR TITLE
Fix chat crash after sending image in chat

### DIFF
--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -336,7 +336,13 @@ def _build_chat_kwargs(
 
     llm_messages: list[dict[str, object]] = [{"role": "system", "content": system_content}]
     for msg in messages:
-        llm_messages.append({"role": msg["role"], "content": msg["content"]})
+        content = msg["content"]
+        # Skip messages with empty content - LLM providers reject them.
+        if isinstance(content, str) and not content:
+            continue
+        if isinstance(content, list) and not content:
+            continue
+        llm_messages.append({"role": msg["role"], "content": content})
 
     kwargs: dict[str, object] = {
         "model": model,


### PR DESCRIPTION
## Summary

- **Preserve multimodal content (images) in chat history** for LLM context. Previously `_extract_text` stripped images during persistence, so the model lost image context on follow-up turns. Image-only messages were stored as empty strings, causing Anthropic to reject subsequent requests with `"user messages must have non-empty content"`.
- **Store multimodal content as JSON** in the DB text column; deserialize it back when loading chat history for LLM calls.
- **Display endpoint** extracts text for the UI, showing `[Image]` for image-only messages.
- **Safety check** in `_build_chat_kwargs` skips messages with empty content as a defensive measure.

## Test plan

- [x] `test_chat_image_only_displays_placeholder` — image-only messages display as `[Image]` in the messages API
- [x] `test_chat_after_image_preserves_multimodal_for_llm` — follow-up chat loads full multimodal content (including image) for the LLM
- [x] `test_chat_multimodal_display_text_only` — text+image messages display text-only in messages API
- [x] `test_chat_multimodal_content_passthrough` — multimodal content still passed through to LLM on first request
- [x] `test_chat_plain_string_still_works` — plain string messages unaffected
- [x] All 103 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)