### PR TITLE
feat: add updated_at field to Song model

### DIFF
--- a/alembic/versions/008_add_song_updated_at.py
+++ b/alembic/versions/008_add_song_updated_at.py
@@ -1,0 +1,35 @@
+"""add song updated_at
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-02-26
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "008"
+down_revision: str | None = "007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "songs",
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+    )
+    # Backfill existing rows: set updated_at = created_at
+    songs = sa.table("songs", sa.column("updated_at"), sa.column("created_at"))
+    op.execute(songs.update().values(updated_at=songs.c.created_at))
+    # Now make it non-nullable
+    with op.batch_alter_table("songs") as batch_op:
+        batch_op.alter_column("updated_at", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("songs", "updated_at")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -82,6 +82,11 @@ class Song(Base):
     status: Mapped[str] = mapped_column(String, default="draft")
     current_version: Mapped[int] = mapped_column(Integer, default=1)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
 
     user: Mapped["User"] = relationship("User", back_populates="songs")
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -127,6 +127,7 @@ class SongOut(BaseModel):
     status: str
     current_version: int
     created_at: datetime
+    updated_at: datetime
 
     model_config = {"from_attributes": True}
 

--- a/frontend/src/components/LibraryTab.tsx
+++ b/frontend/src/components/LibraryTab.tsx
@@ -294,7 +294,7 @@ function SongMenu({ song, onDelete, onRename, onEdit, folders, onMoveToFolder, o
   );
 }
 
-type SortKey = 'date' | 'title' | 'artist';
+type SortKey = 'date' | 'modified' | 'title' | 'artist';
 type SortDir = 'asc' | 'desc';
 
 type DialogState =
@@ -368,6 +368,9 @@ export default function LibraryTab() {
           break;
         case 'artist':
           cmp = (a.artist || '').localeCompare(b.artist || '');
+          break;
+        case 'modified':
+          cmp = new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime();
           break;
         case 'date':
         default:
@@ -702,7 +705,8 @@ export default function LibraryTab() {
             value={sortKey}
             onChange={(e) => setSortKey(e.target.value as SortKey)}
           >
-            <option value="date">Date</option>
+            <option value="date">Created</option>
+            <option value="modified">Modified</option>
             <option value="title">Title</option>
             <option value="artist">Artist</option>
           </Select>

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -937,6 +937,11 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
         };
         /** SongRevisionOut */
         SongRevisionOut: {


### PR DESCRIPTION
## Summary

- Added `updated_at` column to `Song` model with `default` and `onupdate` (matching Profile's existing pattern)
- Added `updated_at: datetime` to `SongOut` schema so it's exposed in the API
- Added "Modified" sort option to the library UI, renamed "Date" to "Created" for clarity
- Regenerated OpenAPI types to include the new field
- Migration 008 adds the column, backfills existing rows with `created_at`, then makes it non-nullable

Fixes njbrake/porchsongs-premium#23

## Test plan

- [x] Backend: 101 tests pass
- [x] Frontend: 57 tests pass
- [x] `ruff check` and `ruff format --check` clean
- [x] `tsc --noEmit` clean
- [x] `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)