### PR TITLE
Add ErrorBoundary and 404 page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate, useParams } from 'react-router-dom';
 import Spinner from '@/components/ui/spinner';
 import LoginPage from '@/components/LoginPage';
+import NotFoundPage from '@/components/NotFoundPage';
 import AppShell from '@/layouts/AppShell';
 import RewriteTab from '@/components/RewriteTab';
 import LibraryTab from '@/components/LibraryTab';
@@ -9,14 +10,8 @@ import { useAuth } from '@/contexts/AuthContext';
 import {
   getPremiumRouteElements,
   getDefaultSettingsTab,
-  getCatchAllRedirect,
   shouldRedirectRootToApp,
 } from '@/extensions';
-
-function CatchAll() {
-  const { isPremium } = useAuth();
-  return <Navigate to={getCatchAllRedirect(isPremium)} replace />;
-}
 
 /** Redirects legacy routes like /library/:id to /app/library/:id */
 function LegacyRedirect({ prefix }: { prefix: string }) {
@@ -65,8 +60,8 @@ export default function App() {
       <Route path="/settings" element={<Navigate to="/app/settings" replace />} />
       <Route path="/settings/:tab" element={<LegacyRedirect prefix="/app/settings" />} />
 
-      {/* Catch-all */}
-      <Route path="*" element={<CatchAll />} />
+      {/* 404 */}
+      <Route path="*" element={<NotFoundPage />} />
     </Routes>
   );
 }

--- a/frontend/src/components/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ErrorBoundary from '@/components/ErrorBoundary';
+
+function ThrowingChild(): React.ReactNode {
+  throw new Error('Test error');
+}
+
+function GoodChild() {
+  return <p>All good</p>;
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    // Suppress React error boundary console.error noise
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders children when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <GoodChild />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('All good')).toBeInTheDocument();
+  });
+
+  it('renders error page when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText(/unexpected error/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reload page' })).toBeInTheDocument();
+  });
+
+  it('calls window.location.reload when reload button is clicked', async () => {
+    const user = userEvent.setup();
+    const reloadMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: reloadMock },
+      writable: true,
+    });
+
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Reload page' }));
+    expect(reloadMock).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('ErrorBoundary caught:', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex items-center justify-center min-h-screen bg-background">
+          <Card className="p-8 sm:p-10 w-full max-w-md mx-4 text-center flex flex-col items-center gap-4 shadow-md">
+            <h1 className="text-2xl font-bold text-foreground">Something went wrong</h1>
+            <p className="text-sm text-muted-foreground">
+              An unexpected error occurred. Please try reloading the page.
+            </p>
+            <Button onClick={() => window.location.reload()}>
+              Reload page
+            </Button>
+          </Card>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/NotFoundPage.test.tsx
+++ b/frontend/src/components/NotFoundPage.test.tsx
@@ -1,0 +1,18 @@
+import { screen } from '@testing-library/react';
+import { renderWithRouter } from '@/test/test-utils';
+import NotFoundPage from '@/components/NotFoundPage';
+
+describe('NotFoundPage', () => {
+  it('renders 404 heading and message', () => {
+    renderWithRouter(<NotFoundPage />);
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByText('Page not found')).toBeInTheDocument();
+    expect(screen.getByText(/doesn.t exist/)).toBeInTheDocument();
+  });
+
+  it('has a link to the app', () => {
+    renderWithRouter(<NotFoundPage />);
+    const link = screen.getByRole('link', { name: 'Go to app' });
+    expect(link).toHaveAttribute('href', '/app');
+  });
+});

--- a/frontend/src/components/NotFoundPage.tsx
+++ b/frontend/src/components/NotFoundPage.tsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+
+export default function NotFoundPage() {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-background">
+      <Card className="p-8 sm:p-10 w-full max-w-md mx-4 text-center flex flex-col items-center gap-4 shadow-md">
+        <h1 className="text-5xl font-bold text-primary">404</h1>
+        <h2 className="text-xl font-bold text-foreground">Page not found</h2>
+        <p className="text-sm text-muted-foreground">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+        <Button asChild>
+          <Link to="/app">Go to app</Link>
+        </Button>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/extensions/index.ts
+++ b/frontend/src/extensions/index.ts
@@ -2,7 +2,6 @@ export { isPremiumAuth } from './auth';
 export {
   getPremiumRouteElements,
   getDefaultSettingsTab,
-  getCatchAllRedirect,
   shouldRedirectRootToApp,
 } from './routes';
 export {

--- a/frontend/src/extensions/routes.tsx
+++ b/frontend/src/extensions/routes.tsx
@@ -8,10 +8,6 @@ export function getDefaultSettingsTab(_isPremium: boolean): string {
   return 'models';
 }
 
-export function getCatchAllRedirect(_isPremium: boolean): string {
-  return '/app';
-}
-
 export function shouldRedirectRootToApp(_isPremium: boolean): boolean {
   return true;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,15 +2,18 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from '@/contexts/AuthContext';
+import ErrorBoundary from '@/components/ErrorBoundary';
 import App from '@/App';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </BrowserRouter>
+    </ErrorBoundary>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Description

Adds graceful error handling for two previously unhandled scenarios:

1. **ErrorBoundary** — Wraps the entire app in `main.tsx` to catch unhandled JS errors. Instead of a blank white screen, users see a friendly "Something went wrong" page with a "Reload page" button.
2. **404 Page** — Replaces the silent catch-all redirect (`CatchAll` → `Navigate`) with a proper `NotFoundPage` component that shows a "Page not found" message with a link back to the app.

Fixes njbrake/porchsongs-premium#14

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

**Any Additional AI Details you'd like to share:** Implemented ErrorBoundary (class component), NotFoundPage, updated routing, and wrote 5 new tests.

- [x] I am an AI Agent filling out this form (check box if true)