### PR TITLE
fix: improve login/logout redirect flow for premium users

### DIFF
--- a/frontend/src/components/LoginPage.test.tsx
+++ b/frontend/src/components/LoginPage.test.tsx
@@ -9,14 +9,15 @@ vi.mock('@/api', () => ({
   },
 }));
 
+const mockHandleLogin = vi.fn();
+let mockAuthConfig: { method: string; required: boolean } = { method: 'password', required: true };
+
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
-    authConfig: { method: 'password', required: true },
+    authConfig: mockAuthConfig,
     handleLogin: mockHandleLogin,
   }),
 }));
-
-const mockHandleLogin = vi.fn();
 
 import api from '@/api';
 
@@ -24,6 +25,7 @@ describe('LoginPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    mockAuthConfig = { method: 'password', required: true };
   });
 
   it('renders the login form', () => {
@@ -60,5 +62,19 @@ describe('LoginPage', () => {
     await user.click(screen.getByText('Log In'));
 
     expect(screen.getByText('Wrong password. Please try again.')).toBeInTheDocument();
+  });
+
+  it('renders OAuth login with back-to-homepage link', () => {
+    mockAuthConfig = { method: 'oauth_google', required: true };
+    renderWithRouter(<LoginPage />);
+    expect(screen.getByText('Sign in with Google')).toBeInTheDocument();
+    const link = screen.getByText('Back to homepage');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/');
+  });
+
+  it('does not show back-to-homepage link for password login', () => {
+    renderWithRouter(<LoginPage />);
+    expect(screen.queryByText('Back to homepage')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -41,6 +41,9 @@ export default function LoginPage() {
           <Button className="w-full mt-1" onClick={() => { window.location.href = '/api/auth/oauth/google'; }}>
             Sign in with Google
           </Button>
+          <a href="/" className="text-sm text-muted-foreground hover:text-foreground underline mt-2">
+            Back to homepage
+          </a>
         </Card>
       </div>
     );

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -62,8 +62,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const handleLogout = useCallback(() => {
     api.logout();
     setCurrentAuthUser(null);
-    setAuthState('login');
-  }, []);
+    if (isPremium) {
+      window.location.href = '/';
+    } else {
+      setAuthState('login');
+    }
+  }, [isPremium]);
 
   const handleLogin = useCallback((user: AuthUser) => {
     setCurrentAuthUser(user);


### PR DESCRIPTION
## Summary
- Premium logout now redirects to the marketing homepage (`/`) via full page load instead of stranding users on `/app/login` with no navigation
- OAuth login page includes a "Back to homepage" link so users can navigate back to the marketing site
- OSS password flow and expired-session redirects are unchanged

## Test plan
- [x] All 64 frontend tests pass
- [x] Typecheck clean
- [ ] Manual: verify premium logout redirects to `/`
- [ ] Manual: verify OAuth login page shows "Back to homepage" link

Fixes njbrake/porchsongs-premium#28

🤖 Generated with [Claude Code](https://claude.com/claude-code)