### PR TITLE
fix: return generic error to frontend on LLM failures

### DIFF
--- a/tests/test_llm_endpoints.py
+++ b/tests/test_llm_endpoints.py
@@ -136,7 +136,9 @@ def test_parse_llm_error(mock_acompletion: MagicMock, client: TestClient) -> Non
         },
     )
     assert resp.status_code == 502
-    assert "LLM error" in resp.json()["detail"]
+    assert "Something went wrong" in resp.json()["detail"]
+    # Raw exception details should NOT leak to the client
+    assert "rate limit" not in resp.json()["detail"]
 
 
 # --- POST /api/chat ---


### PR DESCRIPTION
## Summary
- `_format_llm_error()` now logs full exception details server-side and returns a generic message to the frontend
- Auth-related errors (missing API key) still return setup instructions since they're operator-facing
- Prevents leaking internal error details (URLs, rate limits, stack info) to end users

## Test plan
- [x] `ruff check` and `ruff format --check` pass
- [x] All 86 backend tests pass
- [x] `test_parse_llm_error` verifies generic message is returned and raw details don't leak
- [x] Frontend lint and typecheck clean

Fixes njbrake/porchsongs-premium#42

🤖 Generated with [Claude Code](https://claude.com/claude-code)