### PR TITLE
feat: add terms_accepted_at field to User model

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -15,6 +15,7 @@ class User(Base):
     role: Mapped[str] = mapped_column(String, default="user")  # "admin" or "user"
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
+    terms_accepted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     profiles: Mapped[list["Profile"]] = relationship("Profile", back_populates="user")
     songs: Mapped[list["Song"]] = relationship("Song", back_populates="user")


### PR DESCRIPTION
## Summary
- Add nullable `terms_accepted_at` datetime column to User model
- Companion to premium PR that adds Terms/Privacy acceptance during OAuth signup

## Test plan
- [x] All 86 OSS backend tests pass
- [x] Ruff lint + format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)