### PR TITLE
feat: add quota extension hooks for premium quota UI

### DIFF
--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -1,7 +1,9 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import Markdown from 'react-markdown';
 import { cn } from '@/lib/utils';
 import api from '@/api';
+import { isQuotaError } from '@/extensions/quota';
 import { Card, CardHeader } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -387,9 +389,16 @@ export default function ChatPanel({ songId, messages, setMessages, llmSettings, 
           <div key={i} className={cn('flex flex-col', msg.role === 'user' ? 'items-end' : 'items-start')}>
             <ChatMessageBubble msg={msg} isStreaming={streaming && i === messages.length - 1} />
             {lastFailedInput && i === messages.length - 1 && msg.role === 'assistant' && msg.content.startsWith('Error:') && (
-              <Button variant="secondary" size="sm" className="mt-1" onClick={handleRetry}>
-                Retry
-              </Button>
+              <div className="flex items-center gap-2 mt-1">
+                <Button variant="secondary" size="sm" onClick={handleRetry}>
+                  Retry
+                </Button>
+                {isQuotaError(msg.content) && (
+                  <Link to="/app/settings/account" className="text-sm font-semibold text-primary underline">
+                    Upgrade your plan
+                  </Link>
+                )}
+              </div>
             )}
           </div>
         ))}

--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useOutletContext } from 'react-router-dom';
+import { useOutletContext, Link } from 'react-router-dom';
 import { toast } from 'sonner';
 import api, { STORAGE_KEYS } from '@/api';
 import ComparisonView from '@/components/ComparisonView';
@@ -22,6 +22,7 @@ import Spinner from '@/components/ui/spinner';
 import StreamingPre from '@/components/ui/streaming-pre';
 import { Alert } from '@/components/ui/alert';
 import { cn, copyToClipboard } from '@/lib/utils';
+import { QuotaBanner, isQuotaError } from '@/extensions/quota';
 import type { AppShellContext } from '@/layouts/AppShell';
 import type { Profile, Song, RewriteResult, RewriteMeta, ChatMessage, LlmSettings, SavedModel, ParseResult } from '@/types';
 
@@ -417,9 +418,18 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
+      {isPremium && <QuotaBanner />}
+
       {error && (
         <Alert variant="error" className="mt-4 mb-4">
-          <span>{error}</span>
+          <div className="flex-1">
+            <span>{error}</span>
+            {isQuotaError(error) && (
+              <Link to="/app/settings/account" className="ml-2 font-semibold text-primary underline">
+                Upgrade your plan
+              </Link>
+            )}
+          </div>
           <Button variant="ghost" size="sm" className="text-error-text p-1 leading-none" onClick={() => setError(null)}>
             &times;
           </Button>

--- a/frontend/src/extensions/index.ts
+++ b/frontend/src/extensions/index.ts
@@ -24,3 +24,4 @@ export type {
   CheckoutResponse,
   PortalResponse,
 } from './types';
+export { QuotaBanner, isQuotaError } from './quota';

--- a/frontend/src/extensions/quota.tsx
+++ b/frontend/src/extensions/quota.tsx
@@ -1,0 +1,9 @@
+/** OSS stub — premium overlay replaces this with real quota UI. */
+
+export function QuotaBanner(): null {
+  return null;
+}
+
+export function isQuotaError(_message: string): boolean {
+  return false;
+}


### PR DESCRIPTION
## Description
Add extension points that the premium overlay uses to display rewrite quota status and upgrade CTAs in the rewrite UI. This is the OSS half of the quota UX improvements (premium half in njbrake/porchsongs-premium#58).

- New `extensions/quota.tsx` stub — exports `QuotaBanner` (returns null) and `isQuotaError` (returns false) in OSS mode. Premium overlay replaces these with real implementations.
- `RewriteTab`: renders `QuotaBanner` when `isPremium` is true; shows "Upgrade your plan" link alongside quota error messages.
- `ChatPanel`: shows "Upgrade your plan" link next to retry button when error is a quota error.

Fixes njbrake/porchsongs-premium#29

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)