### PR TITLE
feat: add OnboardingBanner extension hook

### DIFF
--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -22,7 +22,7 @@ import Spinner from '@/components/ui/spinner';
 import StreamingPre from '@/components/ui/streaming-pre';
 import { Alert } from '@/components/ui/alert';
 import { cn, copyToClipboard } from '@/lib/utils';
-import { QuotaBanner, isQuotaError } from '@/extensions/quota';
+import { QuotaBanner, OnboardingBanner, isQuotaError } from '@/extensions/quota';
 import type { AppShellContext } from '@/layouts/AppShell';
 import type { Profile, Song, RewriteResult, RewriteMeta, ChatMessage, LlmSettings, SavedModel, ParseResult } from '@/types';
 
@@ -440,6 +440,8 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
       {isInput && !loading && (
         <>
           {!isPremium && modelControls()}
+
+          <OnboardingBanner />
 
           <Card>
             <CardContent className="pt-6">

--- a/frontend/src/extensions/index.ts
+++ b/frontend/src/extensions/index.ts
@@ -24,4 +24,4 @@ export type {
   CheckoutResponse,
   PortalResponse,
 } from './types';
-export { QuotaBanner, isQuotaError } from './quota';
+export { QuotaBanner, OnboardingBanner, isQuotaError } from './quota';

--- a/frontend/src/extensions/quota.tsx
+++ b/frontend/src/extensions/quota.tsx
@@ -4,6 +4,10 @@ export function QuotaBanner(): null {
   return null;
 }
 
+export function OnboardingBanner(): null {
+  return null;
+}
+
 export function isQuotaError(_message: string): boolean {
   return false;
 }


### PR DESCRIPTION
## Description
Add `OnboardingBanner` to the quota extension stub (returns null in OSS). RewriteTab renders it in the INPUT state so the premium overlay can show a welcome card for new users on first visit.

Fixes njbrake/porchsongs-premium#25

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)