### PR TITLE
test: e2e auto-save after parse appears in library

### DIFF
--- a/e2e/oss/song-lifecycle.spec.ts
+++ b/e2e/oss/song-lifecycle.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+import {
+  waitForAppReady,
+  navigateToTab,
+  mockProviders,
+  mockProviderModels,
+  presetLlmSettings,
+  createSongViaApi,
+  getDefaultProfileId,
+} from '../fixtures/test-helpers';
+import {
+  interceptLlmEndpoints,
+  mockParseStreamResponse,
+  mockChatStreamResponse,
+} from '../fixtures/mock-sse';
+import {
+  RAW_LYRICS,
+  PARSED_TITLE,
+  PARSED_ARTIST,
+  PARSED_CONTENT,
+  REWRITTEN_CONTENT,
+  CHANGES_SUMMARY,
+} from '../fixtures/mock-data';
+
+test.describe('Song Lifecycle', () => {
+  test.beforeEach(async ({ page, baseURL }) => {
+    await presetLlmSettings(page, baseURL!);
+    await mockProviders(page);
+    await mockProviderModels(page);
+  });
+
+  test('parsed song is saved on first chat and appears in library', async ({ page }) => {
+    // Mock both parse and chat SSE endpoints
+    const parseResponse = mockParseStreamResponse(PARSED_CONTENT, {
+      original_content: PARSED_CONTENT,
+      title: PARSED_TITLE,
+      artist: PARSED_ARTIST,
+      reasoning: null,
+    });
+
+    const chatResponse = mockChatStreamResponse(
+      `<content>\n${REWRITTEN_CONTENT}\n</content>\n\n${CHANGES_SUMMARY}`,
+      {
+        rewritten_content: REWRITTEN_CONTENT,
+        original_content: null,
+        assistant_message: CHANGES_SUMMARY,
+        changes_summary: CHANGES_SUMMARY,
+        version: 2,
+        reasoning: null,
+        usage: null,
+      },
+    );
+
+    await interceptLlmEndpoints(page, {
+      parseBody: parseResponse,
+      chatBody: chatResponse,
+    });
+
+    // Navigate and parse
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    const textarea = page.getByPlaceholder(/Paste your lyrics/);
+    await textarea.fill(RAW_LYRICS);
+    await page.getByRole('button', { name: 'Parse' }).click();
+
+    // Wait for parse to complete
+    await expect(page.getByPlaceholder('Song title')).toHaveValue(PARSED_TITLE, { timeout: 10_000 });
+
+    // Send a chat message — this triggers auto-save via onBeforeSend
+    const chatInput = page.getByPlaceholder('Tell the AI how to change the song...');
+    await expect(chatInput).toBeVisible({ timeout: 5_000 });
+    await chatInput.fill('Change "wretch" to "soul"');
+    await page.getByRole('button', { name: 'Send' }).click();
+
+    // Wait for the chat response to complete (assistant message appears)
+    await expect(page.getByText(CHANGES_SUMMARY).first()).toBeVisible({ timeout: 10_000 });
+
+    // Now navigate to Library and verify the song appears
+    await navigateToTab(page, 'Library');
+    await expect(page.getByText(PARSED_TITLE).first()).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText(new RegExp(`by ${PARSED_ARTIST}`)).first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Description

Adds a Playwright e2e test that verifies the full song lifecycle: paste lyrics → parse via SSE → send first chat message (triggers auto-save via `onBeforeSend`) → navigate to Library → confirm the song appears with correct title and artist.

Fixes #43

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Test structure follows existing patterns in `rewrite-flow.spec.ts` and `library.spec.ts`. Uses existing `mock-sse.ts` fixtures for SSE endpoint interception.

- [x] I am an AI Agent filling out this form (check box if true)