### PR TITLE
test: e2e chat history persists on reopen

### DIFF
--- a/e2e/fixtures/test-helpers.ts
+++ b/e2e/fixtures/test-helpers.ts
@@ -72,6 +72,22 @@ export async function mockProviderModels(page: Page): Promise<void> {
   });
 }
 
+/** Seed chat messages for a song via the API. */
+export async function createChatMessagesViaApi(
+  baseUrl: string,
+  songId: number,
+  messages: Array<{ role: string; content: string; is_note?: boolean }>
+): Promise<void> {
+  const res = await fetch(`${baseUrl}/api/songs/${songId}/messages`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(messages),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to create messages: ${res.status} ${await res.text()}`);
+  }
+}
+
 /** Set localStorage keys to pre-configure a provider+model so tests skip model selection. */
 export async function presetLlmSettings(page: Page, baseUrl: string): Promise<void> {
   await page.goto(baseUrl);


### PR DESCRIPTION
## Description

Adds a Playwright e2e test verifying that chat history persists when reopening a song. Seeds a song with chat messages via API, loads it from the library, and asserts both user and assistant messages appear. Navigates away and back to confirm messages survive the round-trip.

Also adds `createChatMessagesViaApi` helper to `test-helpers.ts` for seeding chat history in tests.

Fixes #46

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)