### PR TITLE
feat: add input size validation on content fields

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -81,7 +81,7 @@ class ProviderConnectionOut(BaseModel):
 # --- Parse ---
 class ParseRequest(BaseModel):
     profile_id: int
-    content: str
+    content: str = Field(max_length=100_000)
     provider: str
     model: str
     reasoning_effort: str | None = None
@@ -99,15 +99,15 @@ class ParseResponse(BaseModel):
 # --- Songs ---
 class SongCreate(BaseModel):
     profile_id: int
-    title: str | None = None
-    artist: str | None = None
+    title: str | None = Field(default=None, max_length=500)
+    artist: str | None = Field(default=None, max_length=500)
     source_url: str | None = None
-    original_content: str
-    rewritten_content: str
+    original_content: str = Field(max_length=100_000)
+    rewritten_content: str = Field(max_length=100_000)
     changes_summary: str | None = None
     llm_provider: str | None = None
     llm_model: str | None = None
-    folder: str | None = None
+    folder: str | None = Field(default=None, max_length=100)
 
 
 class SongOut(BaseModel):
@@ -147,12 +147,12 @@ class SongRevisionOut(BaseModel):
 
 
 class SongUpdate(BaseModel):
-    title: str | None = None
-    artist: str | None = None
-    original_content: str | None = None
-    rewritten_content: str | None = None
+    title: str | None = Field(default=None, max_length=500)
+    artist: str | None = Field(default=None, max_length=500)
+    original_content: str | None = Field(default=None, max_length=100_000)
+    rewritten_content: str | None = Field(default=None, max_length=100_000)
     font_size: float | None = Field(default=None, ge=0, le=100)
-    folder: str | None = None
+    folder: str | None = Field(default=None, max_length=100)
 
 
 class FolderRename(BaseModel):
@@ -172,7 +172,7 @@ class ChatMessage(BaseModel):
 
 class ChatMessageCreate(BaseModel):
     role: str
-    content: str
+    content: str = Field(max_length=10_000)
     is_note: bool = False
 
 


### PR DESCRIPTION
## Description

Adds `max_length` constraints to Pydantic schemas to prevent abuse and accidental resource exhaustion. FastAPI returns 422 automatically when limits are exceeded.

Limits added:
- `ParseRequest.content`: 100,000 chars
- `SongCreate/SongUpdate.original_content`, `rewritten_content`: 100,000 chars
- `SongCreate/SongUpdate.title`, `artist`: 500 chars
- `SongCreate/SongUpdate.folder`: 100 chars
- `ChatMessageCreate.content`: 10,000 chars

Fixes #36

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Claude Opus 4.6)

- [x] I am an AI Agent filling out this form (check box if true)