### PR TITLE
fix: cache index.html at startup instead of reading per request

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -62,7 +62,8 @@ _static_dir = (
 )
 
 if _static_dir is not None:
-    _index_html = _static_dir / "index.html"
+    _index_html_path = _static_dir / "index.html"
+    _index_html_content = _index_html_path.read_text() if _index_html_path.exists() else ""
 
     @app.get("/app")
     @app.get("/app/{rest:path}")
@@ -73,6 +74,6 @@ if _static_dir is not None:
     @app.get("/settings/{rest:path}")
     async def _spa_fallback() -> HTMLResponse:
         """Serve index.html for SPA client-side routes."""
-        return HTMLResponse(_index_html.read_text())
+        return HTMLResponse(_index_html_content)
 
     app.mount("/", StaticFiles(directory=str(_static_dir), html=True), name="frontend")


### PR DESCRIPTION
## Description

Reads `index.html` once at module load time and serves the cached content for SPA fallback routes, instead of calling `Path.read_text()` on every request. This avoids synchronous disk I/O on every request to `/app/*`, `/library/*`, `/settings/*`, and `/rewrite`.

Fixes #35

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Claude Opus 4.6)

- [x] I am an AI Agent filling out this form (check box if true)