### PR TITLE
feat: add image size validation and noscript fallback

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,14 @@
 </head>
 <body>
   <div id="root"></div>
+  <noscript>
+    <div style="display:flex;align-items:center;justify-content:center;min-height:100vh;font-family:system-ui,sans-serif;padding:2rem;text-align:center">
+      <div>
+        <h1 style="font-size:1.5rem;margin-bottom:0.5rem">JavaScript Required</h1>
+        <p style="color:#666">porchsongs requires JavaScript to run. Please enable it in your browser settings.</p>
+      </div>
+    </div>
+  </noscript>
   <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import Markdown from 'react-markdown';
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import api from '@/api';
 import { isQuotaError } from '@/extensions/quota';
@@ -120,9 +121,14 @@ export default function ChatPanel({ songId, messages, setMessages, llmSettings, 
   const abortRef = useRef<AbortController | null>(null);
 
   const processFiles = useCallback(async (files: FileList | File[]) => {
+    const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5 MB
     const imageFiles = Array.from(files).filter(f => f.type.startsWith('image/'));
     const newImages: AttachedImage[] = [];
     for (const file of imageFiles) {
+      if (file.size > MAX_IMAGE_SIZE) {
+        toast.error(`Image "${file.name}" is too large (max 5 MB)`);
+        continue;
+      }
       const dataUrl = await fileToBase64(file);
       newImages.push({ dataUrl, name: file.name });
     }


### PR DESCRIPTION
## Description

Two small improvements:

1. **Image size validation** (ChatPanel): Rejects images larger than 5 MB before base64 encoding, showing a toast error. Prevents browser memory exhaustion from oversized image uploads.

2. **noscript fallback** (index.html): Shows a "JavaScript Required" message when JS is disabled, instead of a blank white screen.

Fixes #40, fixes #41

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Claude Opus 4.6)

- [x] I am an AI Agent filling out this form (check box if true)