### PR TITLE
fix: expand parse thinking box from 240px to 50vh

### DIFF
--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -546,7 +546,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
                       {parseReasoningExpanded ? 'Hide parse thinking' : 'Show parse thinking'}
                     </button>
                     {parseReasoningExpanded && (
-                      <pre className="whitespace-pre-wrap break-words text-xs mt-1 font-mono max-h-60 overflow-y-auto opacity-70">{parseResult.reasoning}</pre>
+                      <pre className="whitespace-pre-wrap break-words text-xs mt-1 font-mono max-h-[50vh] overflow-y-auto opacity-70">{parseResult.reasoning}</pre>
                     )}
                   </div>
                 )}


### PR DESCRIPTION
## Description

The collapsed thinking box in the PARSED state used `max-h-60` (240px fixed) which caused it to stop well before the bottom of the screen. Changed to `max-h-[50vh]` to match the streaming thinking box behavior during parsing and fill more available space.

Fixes #23

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Claude Opus 4.6)

- [x] I am an AI Agent filling out this form (check box if true)