### PR TITLE
fix: add missing Alembic migration for users.terms_accepted_at

### DIFF
--- a/alembic/versions/009_add_user_terms_accepted_at.py
+++ b/alembic/versions/009_add_user_terms_accepted_at.py
@@ -1,0 +1,29 @@
+"""add user terms_accepted_at
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-02-27
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "009"
+down_revision: str | None = "008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("terms_accepted_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "terms_accepted_at")


### PR DESCRIPTION
## Description

The `terms_accepted_at` column was added to the `User` model in `models.py` but no Alembic migration was created. This caused a production crash on startup because PostgreSQL didn't have the column.

**Root cause**: Backend tests use `Base.metadata.create_all()` on in-memory SQLite, which creates tables directly from Python model definitions — completely bypassing Alembic migrations. So the tests passed even though the migration was missing.

This PR adds the missing migration (`009_add_user_terms_accepted_at`).

After deploying, run `alembic upgrade head` to apply the migration to production.

Fixes #55

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Migration generated and verified by Claude Code.

- [x] I am an AI Agent filling out this form (check box if true)