### PR TITLE
feat: add 'off' as a supported reasoning effort setting

### DIFF
--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -390,6 +390,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
           disabled={disabled}
           onChange={e => onChangeReasoningEffort(e.target.value)}
         >
+          <option value="off">Off</option>
           <option value="low">Low</option>
           <option value="medium">Medium</option>
           <option value="high">High</option>

--- a/frontend/src/components/settings/ModelsTab.tsx
+++ b/frontend/src/components/settings/ModelsTab.tsx
@@ -70,6 +70,7 @@ export default function ModelsTab({
           onChange={(e: ChangeEvent<HTMLSelectElement>) => onChangeReasoningEffort(e.target.value)}
           className="max-w-[200px]"
         >
+          <option value="off">Off</option>
           <option value="low">Low</option>
           <option value="medium">Medium</option>
           <option value="high">High</option>

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from app.services.llm_service import (
     _build_chat_kwargs,
+    _build_parse_kwargs,
     _parse_chat_response,
     _parse_clean_response,
 )
@@ -32,6 +33,40 @@ def test_build_chat_kwargs_system_prompt() -> None:
     # User/assistant messages passed through unchanged
     assert kwargs["messages"][1] == {"role": "user", "content": "make it sadder"}  # type: ignore[index]
     assert kwargs["messages"][2] == {"role": "assistant", "content": "ok"}  # type: ignore[index]
+
+
+def test_build_chat_kwargs_reasoning_effort_off() -> None:
+    """reasoning_effort='off' should be passed through to disable thinking."""
+    song = SimpleNamespace(
+        original_content="G  Am\nHello world",
+        rewritten_content="G  Am\nHello changed world",
+    )
+    messages = [{"role": "user", "content": "make it sadder"}]
+    kwargs = _build_chat_kwargs(song, messages, "openai", "gpt-4o", reasoning_effort="off")
+    assert kwargs["reasoning_effort"] == "off"
+
+
+def test_build_chat_kwargs_reasoning_effort_high() -> None:
+    """reasoning_effort='high' should be included in kwargs."""
+    song = SimpleNamespace(
+        original_content="G  Am\nHello world",
+        rewritten_content="G  Am\nHello changed world",
+    )
+    messages = [{"role": "user", "content": "make it sadder"}]
+    kwargs = _build_chat_kwargs(song, messages, "openai", "gpt-4o", reasoning_effort="high")
+    assert kwargs["reasoning_effort"] == "high"
+
+
+def test_build_parse_kwargs_reasoning_effort_off() -> None:
+    """reasoning_effort='off' should be passed through to disable thinking."""
+    kwargs = _build_parse_kwargs("some content", "openai", "gpt-4o", reasoning_effort="off")
+    assert kwargs["reasoning_effort"] == "off"
+
+
+def test_build_parse_kwargs_reasoning_effort_low() -> None:
+    """reasoning_effort='low' should be included in kwargs."""
+    kwargs = _build_parse_kwargs("some content", "openai", "gpt-4o", reasoning_effort="low")
+    assert kwargs["reasoning_effort"] == "low"
 
 
 # --- _parse_chat_response ---


### PR DESCRIPTION
## Description

Adds "Off" as an option in the reasoning effort dropdown. Some LLM providers enable extended thinking by default, so users need a way to explicitly disable it. The value `"off"` is passed through to the LLM SDK like any other reasoning effort level.

Fixes #90

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)