### PR TITLE
feat: remove share feature

### DIFF
--- a/frontend/src/components/RewriteTab.test.tsx
+++ b/frontend/src/components/RewriteTab.test.tsx
@@ -120,7 +120,7 @@ describe('RewriteTab', () => {
     expect(resizable.className).toContain('flex-1');
   });
 
-  it('collapses Share and Scrap into overflow menu on mobile in workshopping state', () => {
+  it('collapses Scrap into overflow menu on mobile in workshopping state', () => {
     const props = makeProps({
       rewriteResult: {
         original_content: '[C]Hello [G]World',
@@ -138,11 +138,8 @@ describe('RewriteTab', () => {
     expect(newSongBtn.className).not.toContain('hidden');
     expect(saveBtn.className).not.toContain('hidden');
 
-    // "Share" and "Scrap This" buttons should be hidden on mobile (have hidden md:inline-flex)
-    const shareBtn = screen.getByRole('button', { name: 'Share' });
+    // "Scrap This" button should be hidden on mobile (have hidden md:inline-flex)
     const scrapBtn = screen.getByRole('button', { name: 'Scrap This' });
-    expect(shareBtn.className).toContain('hidden');
-    expect(shareBtn.className).toContain('md:inline-flex');
     expect(scrapBtn.className).toContain('hidden');
     expect(scrapBtn.className).toContain('md:inline-flex');
 


### PR DESCRIPTION
## Description

Removes the share feature entirely. It only copied a markdown summary to the clipboard, which isn't a real share experience. Can be rebuilt properly when a real share feature is designed.

- Removed `handleShare` callback and desktop Share button
- Removed Share menu item from mobile overflow dropdown
- Cleaned up unused imports (`toast`, `copyToClipboard`, `DropdownMenuSeparator`)
- Updated test to match

Fixes #92

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)