### PR TITLE
ci: add migration drift check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,25 @@ jobs:
       - name: Tests
         run: cd frontend && npx vitest run
 
+  migration-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Check migrations match models
+        run: |
+          DATABASE_URL="sqlite:///migration_check.db" uv run alembic upgrade head
+          DATABASE_URL="sqlite:///migration_check.db" uv run alembic check
+
   e2e:
     runs-on: ubuntu-latest
     needs: [test, frontend]


### PR DESCRIPTION
## Summary
- Adds a `migration-check` CI job that runs `alembic upgrade head` + `alembic check` against a temporary SQLite DB
- Catches model column additions that lack a corresponding Alembic migration — the exact bug that caused the `terms_accepted_at` production crash

## Test plan
- [x] `alembic check` passes locally against fresh DB
- [x] All 99 backend tests pass
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)