### PR TITLE
fix: use 'none' instead of 'off' for reasoning effort

### DIFF
--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -359,7 +359,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
           disabled={disabled}
           onChange={e => onChangeReasoningEffort(e.target.value)}
         >
-          <option value="off">Off</option>
+          <option value="none">Off</option>
           <option value="low">Low</option>
           <option value="medium">Medium</option>
           <option value="high">High</option>
@@ -414,7 +414,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
           onChange={e => onChangeReasoningEffort(e.target.value)}
           aria-label="Reasoning effort"
         >
-          <option value="off">Effort: Off</option>
+          <option value="none">Effort: Off</option>
           <option value="low">Effort: Low</option>
           <option value="medium">Effort: Med</option>
           <option value="high">Effort: High</option>

--- a/frontend/src/components/settings/ModelsTab.tsx
+++ b/frontend/src/components/settings/ModelsTab.tsx
@@ -70,7 +70,7 @@ export default function ModelsTab({
           onChange={(e: ChangeEvent<HTMLSelectElement>) => onChangeReasoningEffort(e.target.value)}
           className="max-w-[200px]"
         >
-          <option value="off">Off</option>
+          <option value="none">Off</option>
           <option value="low">Low</option>
           <option value="medium">Medium</option>
           <option value="high">High</option>


### PR DESCRIPTION
## Summary

- The `any-llm` SDK validates `reasoning_effort` against a Literal type that accepts `'none'` but not `'off'`
- All three reasoning effort dropdowns (RewriteTab desktop, RewriteTab mobile, ModelsTab settings) were sending `'off'` which caused a Pydantic `ValidationError`
- Changed the option value from `"off"` to `"none"` in all locations — the label still displays "Off" to the user

## Test plan

- [x] Frontend tests pass
- [ ] CI passes
- [ ] Manual: select "Off" reasoning effort, send a parse/chat request — no validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)