### PR TITLE
fix: improve assistant chat bubble contrast

### DIFF
--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -39,7 +39,7 @@ function ChatMessageBubble({ msg, isStreaming }: { msg: ChatMessage; isStreaming
     ? 'bg-warning-bg text-warning-text self-center text-xs italic'
     : msg.role === 'user'
       ? 'bg-primary text-white self-end rounded-br-sm'
-      : 'bg-panel text-foreground self-start rounded-bl-sm';
+      : 'bg-card text-foreground self-start rounded-bl-sm border border-border';
 
   return (
     <div className={cn('px-3 py-2 rounded-md text-sm leading-normal max-w-[95%] sm:max-w-[85%] break-words', bubbleClass)}>


### PR DESCRIPTION
## Summary

- Assistant chat bubbles used `bg-panel` which is the same color as the flat-mode chat container (`md:bg-panel`), making them invisible against the background
- Changed to `bg-card` with a `border border-border` for clear visual separation
- Works in both light mode (`#ffffff` card on `#f5f4f2` panel) and dark mode (`#292524` card on `#1c1917` panel)

## Test plan

- [x] ChatPanel unit tests pass (9/9)
- [ ] CI passes
- [ ] Visual: assistant bubbles visibly distinct from chat background in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)