### PR TITLE
fix: Library tab navigates back to library list from song view

### DIFF
--- a/frontend/src/components/LibraryTab.navigation.test.tsx
+++ b/frontend/src/components/LibraryTab.navigation.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, Outlet, useNavigate } from 'react-router-dom';
+import type { AppShellContext } from '@/layouts/AppShell';
+import type { Song } from '@/types';
+
+const MOCK_SONG = vi.hoisted<Song>(() => ({
+  id: 42,
+  user_id: 1,
+  profile_id: 1,
+  title: 'Amazing Grace',
+  artist: 'John Newton',
+  source_url: null,
+  original_content: 'Amazing grace how sweet the sound',
+  rewritten_content: 'Amazing grace how sweet the sound',
+  changes_summary: null,
+  llm_provider: null,
+  llm_model: null,
+  status: 'completed',
+  current_version: 1,
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-01T00:00:00Z',
+}));
+
+// Mock api module to return our test song
+vi.mock('@/api', () => ({
+  default: {
+    listSongs: vi.fn().mockResolvedValue([MOCK_SONG]),
+    getSong: vi.fn().mockResolvedValue(MOCK_SONG),
+  },
+  STORAGE_KEYS: {
+    PROVIDER: 'test_provider',
+    MODEL: 'test_model',
+    REASONING_EFFORT: 'test_effort',
+    CURRENT_SONG_ID: 'test_song_id',
+  },
+}));
+
+// Minimal context stub for LibraryTab
+const stubContext: AppShellContext = {
+  profile: { id: 1, is_default: true } as AppShellContext['profile'],
+  llmSettings: { provider: '', model: '', reasoning_effort: 'high' },
+  rewriteResult: null,
+  rewriteMeta: null,
+  currentSongId: null,
+  chatMessages: [],
+  setChatMessages: vi.fn(),
+  onNewRewrite: vi.fn(),
+  onSongSaved: vi.fn(),
+  onContentUpdated: vi.fn(),
+  onChangeProvider: vi.fn(),
+  onChangeModel: vi.fn(),
+  reasoningEffort: 'high',
+  onChangeReasoningEffort: vi.fn(),
+  savedModels: [],
+  onOpenSettings: vi.fn(),
+  isPremium: false,
+  provider: '',
+  model: '',
+  onSave: vi.fn(),
+  onAddModel: vi.fn() as AppShellContext['onAddModel'],
+  onRemoveModel: vi.fn() as AppShellContext['onRemoveModel'],
+  connections: [],
+  onAddConnection: vi.fn() as AppShellContext['onAddConnection'],
+  onRemoveConnection: vi.fn(),
+  onSaveProfile: vi.fn(),
+  onLoadSong: vi.fn(),
+};
+
+/** Layout wrapper that provides AppShellContext via Outlet */
+function ContextWrapper() {
+  return <Outlet context={stubContext} />;
+}
+
+/** Button that navigates to /app/library, simulating a tab click */
+function NavButton() {
+  const navigate = useNavigate();
+  return (
+    <button data-testid="go-library" onClick={() => navigate('/app/library')}>
+      Library Tab
+    </button>
+  );
+}
+
+import LibraryTab from '@/components/LibraryTab';
+
+describe('LibraryTab navigation (issue #94)', () => {
+  it('returns to song list when navigating from /app/library/:id to /app/library', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/app/library/42']}>
+        <NavButton />
+        <Routes>
+          <Route path="/app" element={<ContextWrapper />}>
+            <Route path="library" element={<LibraryTab />} />
+            <Route path="library/:id" element={<LibraryTab />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Wait for the song detail view to render (shows the song title as heading)
+    await waitFor(() => {
+      expect(screen.getByText('Amazing Grace')).toBeInTheDocument();
+    });
+
+    // The "All Songs" back button should be visible (detail view indicator)
+    expect(screen.getByRole('button', { name: /all songs/i })).toBeInTheDocument();
+
+    // Click the Library tab (simulated via NavButton navigating to /app/library)
+    await user.click(screen.getByTestId('go-library'));
+
+    // After navigating to /app/library, the detail view should be gone
+    // and we should see the song list instead
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /all songs/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/LibraryTab.tsx
+++ b/frontend/src/components/LibraryTab.tsx
@@ -407,6 +407,9 @@ export default function LibraryTab() {
         setShowDetails(false);
         setRevisions([]);
       }
+    } else if (initialSongId == null) {
+      // URL changed to /app/library (no song id) — return to list view
+      setViewingSong(null);
     }
   }, [initialSongId, loaded, songs]);
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -3,6 +3,13 @@ import '@testing-library/jest-dom/vitest';
 // jsdom doesn't implement scrollIntoView
 Element.prototype.scrollIntoView = () => {};
 
+// jsdom doesn't implement ResizeObserver
+globalThis.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof globalThis.ResizeObserver;
+
 // jsdom doesn't implement matchMedia
 Object.defineProperty(window, 'matchMedia', {
   writable: true,


### PR DESCRIPTION
## Description
Fixes a bug where clicking the 'Library' tab while viewing a song at `/app/library/:id` didn't navigate back to the library list view at `/app/library`.

**Root cause**: Both `/app/library` and `/app/library/:id` render the same `LibraryTab` component. When React Router navigates between them, it reuses the component instance. The `useEffect` that syncs `viewingSong` state from the URL param only handled the case where `initialSongId` was set, but never cleared `viewingSong` when `initialSongId` became `null`.

**Fix**: Added an `else if (initialSongId == null)` branch that clears `viewingSong`, returning the user to the song list view.

## PR Type
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test plan
- [x] Added regression test (`LibraryTab.navigation.test.tsx`) that reproduces the bug
- [x] Test fails without the fix, passes with the fix
- [x] All 109 frontend tests pass
- [x] All 99 backend tests pass
- [x] ESLint, Ruff, and TypeScript checks pass

## AI Usage
- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

- [x] I am an AI Agent filling out this form (check box if true)

Closes #94