### PR TITLE
feat: use UUID in song URLs instead of integer IDs

### DIFF
--- a/alembic/versions/002_add_song_uuid.py
+++ b/alembic/versions/002_add_song_uuid.py
@@ -1,0 +1,44 @@
+"""add uuid column to songs
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-02-27
+
+"""
+
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "002"
+down_revision: str | None = "001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 1. Add uuid column as nullable first (so existing rows don't fail)
+    op.add_column("songs", sa.Column("uuid", sa.String(), nullable=True))
+
+    # 2. Backfill existing songs with UUIDs
+    conn = op.get_bind()
+    songs = conn.execute(sa.text("SELECT id FROM songs WHERE uuid IS NULL"))
+    for row in songs:
+        conn.execute(
+            sa.text("UPDATE songs SET uuid = :uuid WHERE id = :id"),
+            {"uuid": str(uuid.uuid4()), "id": row[0]},
+        )
+
+    # 3. Make the column non-nullable
+    with op.batch_alter_table("songs") as batch_op:
+        batch_op.alter_column("uuid", nullable=False)
+        batch_op.create_index("ix_songs_uuid", ["uuid"], unique=True)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("songs") as batch_op:
+        batch_op.drop_index("ix_songs_uuid")
+        batch_op.drop_column("uuid")

--- a/backend/app/auth/scoping.py
+++ b/backend/app/auth/scoping.py
@@ -13,8 +13,16 @@ def get_user_profile(db: Session, user: User, profile_id: int) -> Profile:
 
 
 def get_user_song(db: Session, user: User, song_id: int) -> Song:
-    """Fetch a song that belongs to the given user, or raise 404."""
+    """Fetch a song by integer ID that belongs to the given user, or raise 404."""
     song = db.query(Song).filter(Song.id == song_id, Song.user_id == user.id).first()
+    if not song:
+        raise HTTPException(status_code=404, detail="Song not found")
+    return song
+
+
+def get_user_song_by_uuid(db: Session, user: User, song_uuid: str) -> Song:
+    """Fetch a song by UUID that belongs to the given user, or raise 404."""
+    song = db.query(Song).filter(Song.uuid == song_uuid, Song.user_id == user.id).first()
     if not song:
         raise HTTPException(status_code=404, detail="Song not found")
     return song

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,3 +1,4 @@
+import uuid as _uuid
 from datetime import UTC, datetime
 
 from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, Text
@@ -74,6 +75,9 @@ class Song(Base):
     __tablename__ = "songs"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    uuid: Mapped[str] = mapped_column(
+        String, unique=True, index=True, nullable=False, default=lambda: str(_uuid.uuid4())
+    )
     user_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("users.id"), index=True, nullable=False
     )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -112,6 +112,7 @@ class SongCreate(BaseModel):
 
 class SongOut(BaseModel):
     id: int
+    uuid: str
     user_id: int
     profile_id: int
     title: str | None

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -222,9 +222,9 @@ const api = {
     });
     if (error) _throwApiError(error, 'Failed to delete folder');
   },
-  getSong: async (id: number) => {
-    const { data, error } = await client.GET('/api/songs/{song_id}', {
-      params: { path: { song_id: id } },
+  getSong: async (ref: string) => {
+    const { data, error } = await client.GET('/api/songs/{song_ref}', {
+      params: { path: { song_ref: ref } },
     });
     if (error) _throwApiError(error, 'Failed to get song');
     return data as Song;
@@ -236,23 +236,23 @@ const api = {
     if (error) _throwApiError(error, 'Failed to save song');
     return data as Song;
   },
-  updateSong: async (id: number, body: Partial<Song>) => {
-    const { data, error } = await client.PUT('/api/songs/{song_id}', {
-      params: { path: { song_id: id } },
+  updateSong: async (ref: string, body: Partial<Song>) => {
+    const { data, error } = await client.PUT('/api/songs/{song_ref}', {
+      params: { path: { song_ref: ref } },
       body: body as never,
     });
     if (error) _throwApiError(error, 'Failed to update song');
     return data as Song;
   },
-  deleteSong: async (id: number) => {
-    const { error } = await client.DELETE('/api/songs/{song_id}', {
-      params: { path: { song_id: id } },
+  deleteSong: async (ref: string) => {
+    const { error } = await client.DELETE('/api/songs/{song_ref}', {
+      params: { path: { song_ref: ref } },
     });
     if (error) _throwApiError(error, 'Failed to delete song');
   },
-  getSongRevisions: async (id: number) => {
-    const { data, error } = await client.GET('/api/songs/{song_id}/revisions', {
-      params: { path: { song_id: id } },
+  getSongRevisions: async (ref: string) => {
+    const { data, error } = await client.GET('/api/songs/{song_ref}/revisions', {
+      params: { path: { song_ref: ref } },
     });
     if (error) _throwApiError(error, 'Failed to get revisions');
     return data as SongRevision[];
@@ -265,9 +265,9 @@ const api = {
     signal?: AbortSignal,
     onReasoning?: (token: string) => void,
   ): Promise<ChatResult & { version: number }> => _streamSse<ChatResult & { version: number }>('/chat/stream', data, onToken, signal, onReasoning),
-  getChatHistory: async (songId: number) => {
-    const { data, error } = await client.GET('/api/songs/{song_id}/messages', {
-      params: { path: { song_id: songId } },
+  getChatHistory: async (songRef: string) => {
+    const { data, error } = await client.GET('/api/songs/{song_ref}/messages', {
+      params: { path: { song_ref: songRef } },
     });
     if (error) _throwApiError(error, 'Failed to get chat history');
     return data as ChatHistoryRow[];
@@ -319,14 +319,14 @@ const api = {
     if (error) _throwApiError(error, 'Failed to delete connection');
   },
 
-  // PDF
-  downloadSongPdf: async (id: number, title: string | null, artist: string | null) => {
+  // PDF — uses UUID
+  downloadSongPdf: async (songUuid: string, title: string | null, artist: string | null) => {
     const filename = `${title || 'Untitled'} - ${artist || 'Unknown'}.pdf`;
-    let res = await fetch(`/api/songs/${id}/pdf`, { headers: _getAuthHeaders() });
+    let res = await fetch(`/api/songs/${songUuid}/pdf`, { headers: _getAuthHeaders() });
     if (res.status === 401) {
       const refreshed = await tryRefresh();
       if (refreshed) {
-        res = await fetch(`/api/songs/${id}/pdf`, { headers: _getAuthHeaders() });
+        res = await fetch(`/api/songs/${songUuid}/pdf`, { headers: _getAuthHeaders() });
       } else {
         window.dispatchEvent(new CustomEvent('porchsongs-logout'));
         throw new Error('Authentication required. Please log in.');

--- a/frontend/src/components/LibraryTab.folder.test.tsx
+++ b/frontend/src/components/LibraryTab.folder.test.tsx
@@ -44,6 +44,7 @@ import api from '@/api';
 function makeSong(overrides: Partial<Song> = {}): Song {
   return {
     id: 1,
+    uuid: `test-uuid-${String(overrides.id ?? 1)}`,
     user_id: 1,
     profile_id: 1,
     title: 'Test Song',
@@ -71,6 +72,7 @@ function setupContext(overrides: Partial<AppShellContext> = {}): void {
     rewriteResult: null,
     rewriteMeta: null,
     currentSongId: null,
+    currentSongUuid: null,
     chatMessages: [] as ChatMessage[],
     setChatMessages: vi.fn(),
     onNewRewrite: vi.fn(),

--- a/frontend/src/components/LibraryTab.navigation.test.tsx
+++ b/frontend/src/components/LibraryTab.navigation.test.tsx
@@ -6,6 +6,7 @@ import type { Song } from '@/types';
 
 const MOCK_SONG = vi.hoisted<Song>(() => ({
   id: 42,
+  uuid: 'test-uuid-123',
   user_id: 1,
   profile_id: 1,
   title: 'Amazing Grace',
@@ -43,6 +44,7 @@ const stubContext: AppShellContext = {
   rewriteResult: null,
   rewriteMeta: null,
   currentSongId: null,
+  currentSongUuid: null,
   chatMessages: [],
   setChatMessages: vi.fn(),
   onNewRewrite: vi.fn(),
@@ -89,7 +91,7 @@ describe('LibraryTab navigation (issue #94)', () => {
     const user = userEvent.setup();
 
     render(
-      <MemoryRouter initialEntries={['/app/library/42']}>
+      <MemoryRouter initialEntries={['/app/library/test-uuid-123']}>
         <NavButton />
         <Routes>
           <Route path="/app" element={<ContextWrapper />}>

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -187,7 +187,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/songs/{song_id}": {
+    "/api/songs/{song_ref}": {
         parameters: {
             query?: never;
             header?: never;
@@ -195,18 +195,18 @@ export interface paths {
             cookie?: never;
         };
         /** Get Song */
-        get: operations["get_song_api_songs__song_id__get"];
+        get: operations["get_song_api_songs__song_ref__get"];
         /** Update Song */
-        put: operations["update_song_api_songs__song_id__put"];
+        put: operations["update_song_api_songs__song_ref__put"];
         post?: never;
         /** Delete Song */
-        delete: operations["delete_song_api_songs__song_id__delete"];
+        delete: operations["delete_song_api_songs__song_ref__delete"];
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/songs/{song_id}/pdf": {
+    "/api/songs/{song_ref}/pdf": {
         parameters: {
             query?: never;
             header?: never;
@@ -214,7 +214,7 @@ export interface paths {
             cookie?: never;
         };
         /** Download Song Pdf */
-        get: operations["download_song_pdf_api_songs__song_id__pdf_get"];
+        get: operations["download_song_pdf_api_songs__song_ref__pdf_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -223,7 +223,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/songs/{song_id}/revisions": {
+    "/api/songs/{song_ref}/revisions": {
         parameters: {
             query?: never;
             header?: never;
@@ -231,7 +231,7 @@ export interface paths {
             cookie?: never;
         };
         /** List Revisions */
-        get: operations["list_revisions_api_songs__song_id__revisions_get"];
+        get: operations["list_revisions_api_songs__song_ref__revisions_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -240,7 +240,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/songs/{song_id}/messages": {
+    "/api/songs/{song_ref}/messages": {
         parameters: {
             query?: never;
             header?: never;
@@ -248,17 +248,17 @@ export interface paths {
             cookie?: never;
         };
         /** List Messages */
-        get: operations["list_messages_api_songs__song_id__messages_get"];
+        get: operations["list_messages_api_songs__song_ref__messages_get"];
         put?: never;
         /** Save Messages */
-        post: operations["save_messages_api_songs__song_id__messages_post"];
+        post: operations["save_messages_api_songs__song_ref__messages_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/songs/{song_id}/status": {
+    "/api/songs/{song_ref}/status": {
         parameters: {
             query?: never;
             header?: never;
@@ -267,7 +267,7 @@ export interface paths {
         };
         get?: never;
         /** Update Song Status */
-        put: operations["update_song_status_api_songs__song_id__status_put"];
+        put: operations["update_song_status_api_songs__song_ref__status_put"];
         post?: never;
         delete?: never;
         options?: never;
@@ -838,6 +838,8 @@ export interface components {
         SongOut: {
             /** Id */
             id: number;
+            /** Uuid */
+            uuid: string;
             /** User Id */
             user_id: number;
             /** Profile Id */
@@ -1474,12 +1476,12 @@ export interface operations {
             };
         };
     };
-    get_song_api_songs__song_id__get: {
+    get_song_api_songs__song_ref__get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                song_id: number;
+                song_ref: string;
             };
             cookie?: never;
         };
@@ -1505,12 +1507,12 @@ export interface operations {
             };
         };
     };
-    update_song_api_songs__song_id__put: {
+    update_song_api_songs__song_ref__put: {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                song_id: number;
+                song_ref: string;
             };
             cookie?: never;
         };
@@ -1540,12 +1542,12 @@ export interface operations {
             };
         };
     };
-    delete_song_api_songs__song_id__delete: {
+    delete_song_api_songs__song_ref__delete: {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                song_id: number;
+                song_ref: string;
             };
             cookie?: never;
         };
@@ -1571,12 +1573,12 @@ export interface operations {
             };
         };
     };
-    download_song_pdf_api_songs__song_id__pdf_get: {
+    download_song_pdf_api_songs__song_ref__pdf_get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                song_id: number;
+                song_ref: string;
             };
             cookie?: never;
         };
@@ -1602,12 +1604,12 @@ export interface operations {
             };
         };
     };
-    list_revisions_api_songs__song_id__revisions_get: {
+    list_revisions_api_songs__song_ref__revisions_get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                song_id: number;
+                song_ref: string;
             };
             cookie?: never;
         };
@@ -1633,12 +1635,12 @@ export interface operations {
             };
         };
     };
-    list_messages_api_songs__song_id__messages_get: {
+    list_messages_api_songs__song_ref__messages_get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                song_id: number;
+                song_ref: string;
             };
             cookie?: never;
         };
@@ -1664,12 +1666,12 @@ export interface operations {
             };
         };
     };
-    save_messages_api_songs__song_id__messages_post: {
+    save_messages_api_songs__song_ref__messages_post: {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                song_id: number;
+                song_ref: string;
             };
             cookie?: never;
         };
@@ -1699,12 +1701,12 @@ export interface operations {
             };
         };
     };
-    update_song_status_api_songs__song_id__status_put: {
+    update_song_status_api_songs__song_ref__status_put: {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                song_id: number;
+                song_ref: string;
             };
             cookie?: never;
         };

--- a/tests/test_song_uuid.py
+++ b/tests/test_song_uuid.py
@@ -1,0 +1,207 @@
+"""Tests for song UUID field behavior."""
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import Profile, Song, User
+
+
+def _make_profile(client: TestClient) -> dict[str, object]:
+    """Helper: create a profile and return it."""
+    return client.post("/api/profiles", json={}).json()
+
+
+def _make_song(client: TestClient) -> dict[str, object]:
+    """Helper: create a profile + song and return the song dict."""
+    profile = _make_profile(client)
+    song = client.post(
+        "/api/songs",
+        json={
+            "profile_id": profile["id"],
+            "title": "UUID Test Song",
+            "artist": "Test Artist",
+            "original_content": "Hello world",
+            "rewritten_content": "Hi world",
+        },
+    ).json()
+    return song
+
+
+# --- UUID creation ---
+
+
+def test_song_has_uuid_on_create(client: TestClient) -> None:
+    """Created songs should have a UUID field."""
+    song = _make_song(client)
+    assert "uuid" in song
+    assert song["uuid"] is not None
+    # Validate it's a proper UUID format
+    parsed = uuid.UUID(song["uuid"])
+    assert str(parsed) == song["uuid"]
+
+
+def test_each_song_gets_unique_uuid(client: TestClient) -> None:
+    """Each new song should get a different UUID."""
+    profile = _make_profile(client)
+    uuids = set()
+    for i in range(5):
+        song = client.post(
+            "/api/songs",
+            json={
+                "profile_id": profile["id"],
+                "original_content": f"Content {i}",
+                "rewritten_content": f"Rewritten {i}",
+            },
+        ).json()
+        uuids.add(song["uuid"])
+    assert len(uuids) == 5
+
+
+def test_uuid_in_list_songs(client: TestClient) -> None:
+    """Listed songs should include their UUID."""
+    song = _make_song(client)
+    resp = client.get("/api/songs")
+    assert resp.status_code == 200
+    songs = resp.json()
+    assert len(songs) == 1
+    assert songs[0]["uuid"] == song["uuid"]
+
+
+# --- UUID-based lookups ---
+
+
+def test_get_song_by_uuid(client: TestClient) -> None:
+    """GET /api/songs/{uuid} should work."""
+    song = _make_song(client)
+    resp = client.get(f"/api/songs/{song['uuid']}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == song["id"]
+    assert data["uuid"] == song["uuid"]
+    assert data["title"] == "UUID Test Song"
+
+
+def test_get_song_by_id_still_works(client: TestClient) -> None:
+    """GET /api/songs/{id} should still work for backward compat."""
+    song = _make_song(client)
+    resp = client.get(f"/api/songs/{song['id']}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["uuid"] == song["uuid"]
+
+
+def test_update_song_by_uuid(client: TestClient) -> None:
+    """PUT /api/songs/{uuid} should work."""
+    song = _make_song(client)
+    resp = client.put(f"/api/songs/{song['uuid']}", json={"title": "Updated Title"})
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Updated Title"
+
+
+def test_delete_song_by_uuid(client: TestClient) -> None:
+    """DELETE /api/songs/{uuid} should work."""
+    song = _make_song(client)
+    resp = client.delete(f"/api/songs/{song['uuid']}")
+    assert resp.status_code == 200
+
+    # Verify it's gone
+    resp = client.get(f"/api/songs/{song['uuid']}")
+    assert resp.status_code == 404
+
+
+def test_get_song_revisions_by_uuid(client: TestClient) -> None:
+    """GET /api/songs/{uuid}/revisions should work."""
+    song = _make_song(client)
+    resp = client.get(f"/api/songs/{song['uuid']}/revisions")
+    assert resp.status_code == 200
+    revisions = resp.json()
+    assert len(revisions) == 1
+    assert revisions[0]["version"] == 1
+
+
+def test_get_song_messages_by_uuid(client: TestClient) -> None:
+    """GET /api/songs/{uuid}/messages should work."""
+    song = _make_song(client)
+    resp = client.get(f"/api/songs/{song['uuid']}/messages")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_save_messages_by_uuid(client: TestClient) -> None:
+    """POST /api/songs/{uuid}/messages should work."""
+    song = _make_song(client)
+    resp = client.post(
+        f"/api/songs/{song['uuid']}/messages",
+        json=[{"role": "user", "content": "Test via UUID"}],
+    )
+    assert resp.status_code == 201
+    assert len(resp.json()) == 1
+
+
+def test_update_song_status_by_uuid(client: TestClient) -> None:
+    """PUT /api/songs/{uuid}/status should work."""
+    song = _make_song(client)
+    resp = client.put(f"/api/songs/{song['uuid']}/status", json={"status": "completed"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "completed"
+
+
+def test_nonexistent_uuid_returns_404(client: TestClient) -> None:
+    """A random UUID that doesn't exist should return 404."""
+    fake_uuid = str(uuid.uuid4())
+    resp = client.get(f"/api/songs/{fake_uuid}")
+    assert resp.status_code == 404
+
+
+# --- UUID model field ---
+
+
+def test_song_model_uuid_auto_generated(db_session: Session, test_user: User) -> None:
+    """Song model should auto-generate a UUID on creation."""
+    profile = Profile(user_id=test_user.id, is_default=True)
+    db_session.add(profile)
+    db_session.commit()
+    db_session.refresh(profile)
+
+    song = Song(
+        user_id=test_user.id,
+        profile_id=profile.id,
+        original_content="Test",
+        rewritten_content="Test",
+    )
+    db_session.add(song)
+    db_session.commit()
+    db_session.refresh(song)
+
+    assert song.uuid is not None
+    parsed = uuid.UUID(song.uuid)
+    assert str(parsed) == song.uuid
+
+
+def test_song_model_uuid_is_unique(db_session: Session, test_user: User) -> None:
+    """Two songs should get different UUIDs."""
+    profile = Profile(user_id=test_user.id, is_default=True)
+    db_session.add(profile)
+    db_session.commit()
+    db_session.refresh(profile)
+
+    song1 = Song(
+        user_id=test_user.id,
+        profile_id=profile.id,
+        original_content="Test 1",
+        rewritten_content="Test 1",
+    )
+    song2 = Song(
+        user_id=test_user.id,
+        profile_id=profile.id,
+        original_content="Test 2",
+        rewritten_content="Test 2",
+    )
+    db_session.add_all([song1, song2])
+    db_session.commit()
+    db_session.refresh(song1)
+    db_session.refresh(song2)
+
+    assert song1.uuid != song2.uuid


### PR DESCRIPTION
## Description

Adds a UUID field to the Song model and uses it in URL routing instead of integer IDs. This provides stable, shareable URLs for songs and prevents sequential ID enumeration.

### Changes

**Backend:**
- Added `uuid` column to Song model with auto-generation via `uuid4()`
- Created alembic migration (002) to add column and backfill existing songs with UUIDs
- Updated all song API endpoints to accept either UUID or integer ID via `_resolve_song()` helper (backward compatible)
- Added `get_user_song_by_uuid()` to scoping module
- Added `uuid` field to `SongOut` schema

**Frontend:**
- Updated library routing to use UUID in URLs (`/app/library/{uuid}`)
- Updated all song API calls (`getSong`, `updateSong`, `deleteSong`, `getSongRevisions`, `getChatHistory`, `downloadSongPdf`) to use UUID strings
- Updated `AppShell` to track both `currentSongId` (integer, for chat requests) and `currentSongUuid` (string, for URL routing and localStorage)
- Updated `LibraryTab` selection, drag-and-drop, and all CRUD operations to use UUID
- Regenerated OpenAPI types with new `uuid` field and `song_ref` path params

**Tests:**
- Added 14 new tests covering UUID creation, uniqueness, UUID-based lookups, and backward compatibility with integer IDs

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Demo

The library URLs now use UUIDs:
- Before: `/app/library/42`
- After: `/app/library/afa2a137-1387-40d0-b1ce-7735bb17c634`

API responses include the UUID:
```json
{
  "id": 2,
  "uuid": "afa2a137-1387-40d0-b1ce-7735bb17c634",
  "title": "Wagon Wheel",
  "artist": "Old Crow Medicine Show",
  ...
}
```

API endpoints accept both UUID and integer ID for backward compatibility:
- `GET /api/songs/afa2a137-1387-40d0-b1ce-7735bb17c634` (UUID)
- `GET /api/songs/2` (integer, backward compat)

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

- [x] I am an AI Agent filling out this form (check box if true)

Closes #102