### PR TITLE
chore: add PR video upload script for agents

### DIFF
--- a/scripts/upload-pr-video.sh
+++ b/scripts/upload-pr-video.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Upload a Playwright-recorded .webm video to a GitHub PR as a release asset
+# and post a comment with the download link.
+#
+# Usage: ./scripts/upload-pr-video.sh <pr-number> <video-file>
+#
+# Prerequisites:
+#   - gh CLI authenticated with push access
+#   - A "ci-assets" pre-release exists on the repo (created once, reused forever)
+#
+# The script:
+#   1. Finds or creates the ci-assets release
+#   2. Uploads the .webm as a release asset with a unique name
+#   3. Posts a PR comment with the download link
+#
+# Note: GitHub does not support inline video playback for release asset URLs.
+# Videos render as download links. For inline playback, manually drag-and-drop
+# the .webm into the PR description via the GitHub web UI.
+
+set -euo pipefail
+
+REPO="${GITHUB_REPO:-njbrake/porchsongs}"
+PR_NUMBER="${1:?Usage: $0 <pr-number> <video-file>}"
+VIDEO_FILE="${2:?Usage: $0 <pr-number> <video-file>}"
+TAG_NAME="ci-assets"
+
+if [ ! -f "$VIDEO_FILE" ]; then
+  echo "Error: Video file not found: $VIDEO_FILE" >&2
+  exit 1
+fi
+
+# Step 1: Get or create the ci-assets release
+RELEASE_ID=$(gh api "repos/${REPO}/releases/tags/${TAG_NAME}" --jq '.id' 2>/dev/null || echo "")
+
+if [ -z "$RELEASE_ID" ]; then
+  echo "Creating ci-assets release..."
+  DEFAULT_SHA=$(gh api "repos/${REPO}/git/ref/heads/main" --jq '.object.sha')
+  gh api "repos/${REPO}/git/refs" --method POST \
+    -f ref="refs/tags/${TAG_NAME}" -f sha="${DEFAULT_SHA}" >/dev/null 2>&1 || true
+  RELEASE_ID=$(gh api "repos/${REPO}/releases" --method POST \
+    -f tag_name="${TAG_NAME}" \
+    -f name="CI Assets" \
+    -f body="Auto-managed release for CI/agent video uploads. Do not delete." \
+    -F draft=false -F prerelease=true --jq '.id')
+  echo "Created release ID: ${RELEASE_ID}"
+fi
+
+# Step 2: Upload video as release asset
+TIMESTAMP=$(date +%s)
+ASSET_NAME="pr-${PR_NUMBER}-demo-${TIMESTAMP}.webm"
+TOKEN=$(gh auth token)
+
+echo "Uploading ${VIDEO_FILE} as ${ASSET_NAME}..."
+UPLOAD_RESPONSE=$(curl -sS \
+  -X POST \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  -H "Content-Type: video/webm" \
+  --data-binary @"${VIDEO_FILE}" \
+  "https://uploads.github.com/repos/${REPO}/releases/${RELEASE_ID}/assets?name=${ASSET_NAME}")
+
+ASSET_URL=$(echo "$UPLOAD_RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin)['browser_download_url'])" 2>/dev/null)
+
+if [ -z "$ASSET_URL" ]; then
+  echo "Error: Upload failed. Response:" >&2
+  echo "$UPLOAD_RESPONSE" >&2
+  exit 1
+fi
+
+echo "Uploaded: ${ASSET_URL}"
+
+# Step 3: Post PR comment with download link
+gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$(cat <<EOF
+## Demo Video
+
+[Download demo video (${ASSET_NAME})](${ASSET_URL})
+
+> Playwright-recorded .webm — download and open in browser to view.
+EOF
+)"
+
+echo "Comment posted on PR #${PR_NUMBER}"
+echo "Video URL: ${ASSET_URL}"

--- a/tips/definition-of-done.md
+++ b/tips/definition-of-done.md
@@ -64,20 +64,22 @@ Videos are saved to `test-results/` as `.webm` files. The filename is auto-gener
 
 ### Attaching to the PR
 
-Upload the `.webm` file to the GitHub PR description by dragging it into the description editor, or use the `gh` CLI:
+**Option A — Manual (inline playback):** Drag the `.webm` file into the PR description editor on GitHub. This is the only way to get inline video playback (GitHub reserves it for `user-attachments/assets/` URLs).
+
+**Option B — Script (download link):** Use the upload script to attach the video as a release asset and post a PR comment with a download link:
 
 ```bash
-# Reference the video in the PR body (GitHub renders .webm inline)
-gh pr create --title "feat: update song card layout" --body "$(cat <<'EOF'
-## Summary
-- Redesigned song card with new chord coloring
+./scripts/upload-pr-video.sh <pr-number> <path-to-video.webm>
+```
 
-## Demo video
-<!-- Drag the .webm file here, or paste after creating the PR -->
+The script uploads the video to the `ci-assets` pre-release and posts a comment on the PR. The video renders as a download link (not inline player) — reviewers click to download and view.
 
-## Test plan
-- [x] Visual verification via Playwright recording
-- [x] Frontend tests pass
-EOF
-)"
+**For AI agents:** Always use Option B after creating a PR with UI changes. The script handles release asset upload and PR commenting automatically. Example workflow:
+
+```bash
+# 1. Record the video (see "How to record" above)
+# 2. Find the video file
+VIDEO_FILE=$(ls -t test-results/*.webm 2>/dev/null | head -1)
+# 3. Upload and comment on the PR
+./scripts/upload-pr-video.sh 123 "$VIDEO_FILE"
 ```


### PR DESCRIPTION
## Description
Adds a script and updated docs for attaching Playwright-recorded demo videos to PRs programmatically.

- `scripts/upload-pr-video.sh` — uploads a .webm to the `ci-assets` pre-release and posts a PR comment with the download link
- Updated `tips/definition-of-done.md` with both manual (drag-and-drop for inline playback) and scripted (release asset for download link) workflows

### Why
GitHub's API does not support inline video attachments (those require browser-based drag-and-drop). The release assets approach is the best available option for agents running in CI/sandbox environments. Research details in the conversation that produced this PR.

## PR Type
- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [x] Infrastructure / CI

## Checklist
- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage
- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

- [x] I am an AI Agent filling out this form (check box if true)