### PR TITLE
fix: consume OAuth refresh token from URL hash fragment

### DIFF
--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -6,6 +6,16 @@ let _accessToken: string | null = null;
 
 const REFRESH_TOKEN_KEY = 'porchsongs_refresh_token';
 
+// Consume refresh token from URL hash fragment (set by OAuth redirect).
+// This runs once at module load, before any auth checks.
+(function _consumeHashToken() {
+  const match = window.location.hash.match(/refresh_token=([^&]+)/);
+  if (match?.[1]) {
+    localStorage.setItem(REFRESH_TOKEN_KEY, match[1]);
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
+})();
+
 function _getRefreshToken(): string | null {
   return localStorage.getItem(REFRESH_TOKEN_KEY);
 }


### PR DESCRIPTION
## Summary
- Adds frontend counterpart for the premium OAuth redirect change (njbrake/porchsongs-premium#92)
- On module load, `api-client.ts` checks for `#refresh_token=...` in the URL hash, stores it in localStorage, and cleans the hash from the URL bar
- This replaces the old flow where an inline `<script>` in the OAuth callback page stored the token — that was being blocked by the CSP `script-src 'self'` header, causing a blank page after login

## Test plan
- [x] 140 OSS frontend tests pass
- [x] TypeScript type check passes
- [x] ESLint clean
- [x] No-op in OSS mode (no hash fragment present, IIFE exits immediately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)