### PR TITLE
Move "Upgrade your plan" links into the extension system

### DIFF
--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -1,10 +1,9 @@
 import { useState, useRef, useEffect, useCallback, type ReactNode } from 'react';
-import { Link } from 'react-router-dom';
 import Markdown from 'react-markdown';
 import { toast } from 'sonner';
 import { cn, stripXmlTags } from '@/lib/utils';
 import api from '@/api';
-import { isQuotaError } from '@/extensions/quota';
+import { isQuotaError, QuotaUpgradeLink } from '@/extensions/quota';
 import { Card, CardHeader } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -401,9 +400,7 @@ export default function ChatPanel({ songId, messages, setMessages, llmSettings, 
                   Retry
                 </Button>
                 {isQuotaError(msg.content) && (
-                  <Link to="/app/settings/account" className="text-sm font-semibold text-primary underline">
-                    Upgrade your plan
-                  </Link>
+                  <QuotaUpgradeLink className="text-sm font-semibold text-primary underline" />
                 )}
               </div>
             )}

--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useOutletContext, Link } from 'react-router-dom';
+import { useOutletContext } from 'react-router-dom';
 import api, { STORAGE_KEYS } from '@/api';
 import ComparisonView from '@/components/ComparisonView';
 import ChatPanel from '@/components/ChatPanel';
@@ -28,7 +28,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { cn, copyToClipboard as copyText } from '@/lib/utils';
-import { QuotaBanner, OnboardingBanner, isQuotaError } from '@/extensions/quota';
+import { QuotaBanner, OnboardingBanner, isQuotaError, QuotaUpgradeLink } from '@/extensions/quota';
 import type { AppShellContext } from '@/layouts/AppShell';
 import type { Profile, Song, RewriteResult, RewriteMeta, ChatMessage, LlmSettings, SavedModel, ParseResult } from '@/types';
 
@@ -452,9 +452,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
           <div className="flex-1">
             <span>{error}</span>
             {isQuotaError(error) && (
-              <Link to="/app/settings/account" className="ml-2 font-semibold text-primary underline">
-                Upgrade your plan
-              </Link>
+              <QuotaUpgradeLink className="ml-2 font-semibold text-primary underline" />
             )}
           </div>
           <Button variant="ghost" size="sm" className="text-error-text p-1 leading-none" onClick={() => setError(null)}>

--- a/frontend/src/extensions/quota.tsx
+++ b/frontend/src/extensions/quota.tsx
@@ -8,6 +8,10 @@ export function OnboardingBanner(): null {
   return null;
 }
 
+export function QuotaUpgradeLink(_props: { className?: string }): null {
+  return null;
+}
+
 export function isQuotaError(_message: string): boolean {
   return false;
 }


### PR DESCRIPTION
## Description

The inline "Upgrade your plan" links in `ChatPanel.tsx` and `RewriteTab.tsx` hardcoded premium-specific UI (the `/app/settings/account` route and "Upgrade your plan" copy) directly in OSS core components. This change moves them into the extension system:

- Added `QuotaUpgradeLink` stub to `extensions/quota.tsx` (returns `null` in OSS)
- Replaced inline `<Link>` elements in both components with `<QuotaUpgradeLink />`
- Removed unused `Link` imports from both files

The premium overlay at `premium/frontend/src/extensions/quota.tsx` has been updated with the real `QuotaUpgradeLink` implementation.

Fixes #118

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)