### PR TITLE
feat: add token usage data to parse endpoints

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -78,6 +78,11 @@ class ProviderConnectionOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class TokenUsage(BaseModel):
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
 # --- Parse ---
 class ParseRequest(BaseModel):
     profile_id: int
@@ -94,6 +99,7 @@ class ParseResponse(BaseModel):
     title: str | None = None
     artist: str | None = None
     reasoning: str | None = None
+    usage: TokenUsage | None = None
 
 
 # --- Songs ---
@@ -199,11 +205,6 @@ class ChatRequest(BaseModel):
     model: str
     reasoning_effort: str | None = None
     max_tokens: int | None = None
-
-
-class TokenUsage(BaseModel):
-    input_tokens: int = 0
-    output_tokens: int = 0
 
 
 class ChatResponse(BaseModel):

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -690,6 +690,7 @@ export interface components {
             artist?: string | null;
             /** Reasoning */
             reasoning?: string | null;
+            usage?: components["schemas"]["TokenUsage"] | null;
         };
         /** ProfileCreate */
         ProfileCreate: {


### PR DESCRIPTION
## Summary
- Parse endpoints (non-streaming and streaming) now return token usage data (`input_tokens`, `output_tokens`) matching the existing chat endpoint pattern
- Adds `usage: TokenUsage | None` field to `ParseResponse` schema
- Enables the premium layer to calculate credit costs based on actual output token counts
- Regenerated OpenAPI types

## Test plan
- [x] All 113 OSS backend tests pass
- [x] TypeScript typecheck passes
- [x] Ruff lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)