### PR TITLE
fix: make feature request test URL-agnostic for premium overlay

### DIFF
--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -81,7 +81,7 @@ describe('AppShell layout', () => {
     renderWithRouter(<AppShell />, { route: '/app/rewrite' });
 
     const link = screen.getByRole('link', { name: /feature request/i });
-    expect(link).toHaveAttribute('href', expect.stringContaining('github.com/njbrake/porchsongs/issues/new'));
+    expect(link).toHaveAttribute('href');
     expect(link).toHaveAttribute('target', '_blank');
   });
 });


### PR DESCRIPTION
## Description

Follow-up to #126. The feature request link test hardcoded the GitHub issues URL, but the premium overlay returns a `mailto:` URL instead. This makes the test assert only that the `href` attribute exists, so it works in both OSS and premium builds.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

- [x] I am an AI Agent filling out this form (check box if true)