### PR TITLE
fix: add identity and guardrails to LLM system prompts

### DIFF
--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -34,8 +34,10 @@ def _get_usage(response: ChatCompletion) -> dict[str, int] | None:
     }
 
 
-CLEAN_SYSTEM_PROMPT = """You are a songwriter's assistant. Your ONLY job is to clean up raw pasted \
-song input. Do NOT rewrite or change the content in any way.
+CLEAN_SYSTEM_PROMPT = """You are PorchSongs, a song lyric editing assistant. You are part of the \
+PorchSongs application, which helps users rewrite and customize song lyrics. \
+Your ONLY job is to clean up raw pasted song input. Do NOT rewrite or change the content in any way. \
+Do NOT engage in discussions or tasks unrelated to song editing.
 
 STEP 1 — IDENTIFY:
 - Determine the song's title and artist from the input
@@ -69,8 +71,15 @@ Artist: <artist name or UNKNOWN>
 </original>"""
 
 
-CHAT_SYSTEM_PROMPT = """You are a songwriter's assistant helping adapt a song.
-You can have a normal conversation — answer questions, discuss options, brainstorm ideas.
+CHAT_SYSTEM_PROMPT = """You are PorchSongs, a song lyric editing assistant. You are part of the \
+PorchSongs application, which helps users rewrite and customize song lyrics.
+
+Stay on topic: only discuss song lyrics, songwriting, chord progressions, and music-related topics. \
+If the user asks about something unrelated to song editing or music, politely decline and redirect \
+the conversation back to their song.
+
+You can have a normal conversation — answer questions, discuss options, brainstorm ideas — as long as \
+it relates to the song or songwriting in general.
 
 When the user wants changes to the song, go ahead and make them. You don't need an explicit \
 "rewrite it" command — if the user's message implies a change (e.g. "the second verse feels \

--- a/tests/test_llm_endpoints.py
+++ b/tests/test_llm_endpoints.py
@@ -449,8 +449,10 @@ def test_get_default_prompts(client: TestClient) -> None:
     data = resp.json()
     assert "parse" in data
     assert "chat" in data
-    assert "songwriter" in data["parse"].lower()
-    assert "songwriter" in data["chat"].lower()
+    assert "porchsongs" in data["parse"].lower()
+    assert "song lyric editing assistant" in data["parse"].lower()
+    assert "porchsongs" in data["chat"].lower()
+    assert "song lyric editing assistant" in data["chat"].lower()
 
 
 # --- System prompt fields on profiles ---

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -3,11 +3,65 @@
 from types import SimpleNamespace
 
 from app.services.llm_service import (
+    CHAT_SYSTEM_PROMPT,
+    CLEAN_SYSTEM_PROMPT,
     _build_chat_kwargs,
     _build_parse_kwargs,
     _parse_chat_response,
     _parse_clean_response,
 )
+
+# --- System prompt guardrails ---
+
+
+def test_clean_system_prompt_identifies_as_porchsongs() -> None:
+    """CLEAN_SYSTEM_PROMPT should identify the LLM as PorchSongs."""
+    assert "PorchSongs" in CLEAN_SYSTEM_PROMPT
+    assert "song lyric editing assistant" in CLEAN_SYSTEM_PROMPT
+
+
+def test_clean_system_prompt_describes_application() -> None:
+    """CLEAN_SYSTEM_PROMPT should explain it is part of the PorchSongs application."""
+    assert "PorchSongs application" in CLEAN_SYSTEM_PROMPT
+    assert "rewrite and customize song lyrics" in CLEAN_SYSTEM_PROMPT
+
+
+def test_clean_system_prompt_declines_off_topic() -> None:
+    """CLEAN_SYSTEM_PROMPT should instruct declining unrelated discussions."""
+    assert "unrelated to song editing" in CLEAN_SYSTEM_PROMPT
+
+
+def test_chat_system_prompt_identifies_as_porchsongs() -> None:
+    """CHAT_SYSTEM_PROMPT should identify the LLM as PorchSongs."""
+    assert "PorchSongs" in CHAT_SYSTEM_PROMPT
+    assert "song lyric editing assistant" in CHAT_SYSTEM_PROMPT
+
+
+def test_chat_system_prompt_describes_application() -> None:
+    """CHAT_SYSTEM_PROMPT should explain it is part of the PorchSongs application."""
+    assert "PorchSongs application" in CHAT_SYSTEM_PROMPT
+    assert "rewrite and customize song lyrics" in CHAT_SYSTEM_PROMPT
+
+
+def test_chat_system_prompt_stays_on_topic() -> None:
+    """CHAT_SYSTEM_PROMPT should instruct staying on-topic and declining unrelated requests."""
+    assert "Stay on topic" in CHAT_SYSTEM_PROMPT
+    assert "politely decline" in CHAT_SYSTEM_PROMPT
+
+
+def test_chat_system_prompt_preserves_existing_instructions() -> None:
+    """CHAT_SYSTEM_PROMPT should still contain existing formatting/chord instructions."""
+    assert "Preserve syllable counts" in CHAT_SYSTEM_PROMPT
+    assert "chord lines" in CHAT_SYSTEM_PROMPT
+    assert "<content>" in CHAT_SYSTEM_PROMPT
+
+
+def test_clean_system_prompt_preserves_existing_instructions() -> None:
+    """CLEAN_SYSTEM_PROMPT should still contain existing cleanup/chord instructions."""
+    assert "CHORD PRESERVATION" in CLEAN_SYSTEM_PROMPT
+    assert "<meta>" in CLEAN_SYSTEM_PROMPT
+    assert "<original>" in CLEAN_SYSTEM_PROMPT
+
 
 # --- _build_chat_kwargs ---
 


### PR DESCRIPTION
## Description

Updates both `CLEAN_SYSTEM_PROMPT` and `CHAT_SYSTEM_PROMPT` in `llm_service.py` to:

- Identify the LLM as "PorchSongs, a song lyric editing assistant"
- Explain it is part of the PorchSongs application that helps users rewrite and customize song lyrics
- Instruct the LLM to stay on-topic and politely decline requests unrelated to song editing or music
- Preserve all existing instructions about formatting, chord preservation, XML tags, etc.

Fixes #128

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:**
All changes were authored by Claude Code following the issue instructions.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)