### PR TITLE
fix: add max_length=2000 to ParseRequest.instruction

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -90,7 +90,7 @@ class ParseRequest(BaseModel):
     provider: str
     model: str
     reasoning_effort: str | None = None
-    instruction: str | None = None
+    instruction: str | None = Field(default=None, max_length=2000)
     max_tokens: int | None = None
 
 


### PR DESCRIPTION
## Summary
- Adds `max_length=2000` to the `ParseRequest.instruction` field in `backend/app/schemas.py`
- Previously, the `instruction` field had no length constraint, allowing arbitrarily large instructions to be appended to the LLM prompt — bypassing the premium layer's `max_input_chars` cost control
- This schema-level validation complements the premium middleware fix in njbrake/porchsongs-premium#116

## Test plan
- [x] All 121 OSS backend tests pass
- [x] Ruff lint and format checks pass
- [ ] Verify Pydantic rejects `instruction` values over 2000 characters with a 422 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)