### PR TITLE
fix: always send max_tokens to prevent Anthropic extended thinking conflict

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     jwt_expiry_minutes: int = 15
     refresh_token_days: int = 30
     premium_plugin: str | None = None
+    default_max_tokens: int = 16384
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -174,8 +174,9 @@ def _build_parse_kwargs(
         kwargs["api_base"] = api_base
     if reasoning_effort:
         kwargs["reasoning_effort"] = reasoning_effort
-    if max_tokens is not None:
-        kwargs["max_tokens"] = max_tokens
+    from ..config import settings
+
+    kwargs["max_tokens"] = max_tokens if max_tokens is not None else settings.default_max_tokens
     return kwargs
 
 
@@ -377,8 +378,9 @@ def _build_chat_kwargs(
         kwargs["api_base"] = api_base
     if reasoning_effort:
         kwargs["reasoning_effort"] = reasoning_effort
-    if max_tokens is not None:
-        kwargs["max_tokens"] = max_tokens
+    from ..config import settings
+
+    kwargs["max_tokens"] = max_tokens if max_tokens is not None else settings.default_max_tokens
     return kwargs
 
 


### PR DESCRIPTION
## Summary

Fixes `anthropic.BadRequestError: max_tokens must be greater than thinking.budget_tokens`.

**Root cause**: The `any_llm` library defaults `reasoning_effort` to `"auto"`, which enables extended thinking on Anthropic. Extended thinking sets `budget_tokens=8192`. When `max_tokens` isn't explicitly provided, the library also defaults it to `8192`. Anthropic requires `max_tokens > budget_tokens`, so `8192 > 8192` fails with a 400 error.

**Fix**: Always send `max_tokens` when calling the LLM. Adds a `DEFAULT_MAX_TOKENS` setting (env var, defaults to `16384`) and uses it whenever the client doesn't specify `max_tokens`. This ensures `max_tokens` is always greater than the thinking budget.

- `backend/app/config.py`: Add `default_max_tokens: int = 16384` setting
- `backend/app/services/llm_service.py`: Both `_build_parse_kwargs()` and `_build_chat_kwargs()` now always include `max_tokens`

## Test plan

- [x] All 121 OSS backend tests pass
- [x] All 225 premium backend tests pass
- [ ] Manual test: send a chat/parse request without `max_tokens` — should use 16384 default
- [ ] Manual test: set `DEFAULT_MAX_TOKENS=4096` — should use 4096

🤖 Generated with [Claude Code](https://claude.com/claude-code)