### PR TITLE
feat: add api_key pass-through and isAdmin context for admin panel

### DIFF
--- a/backend/app/routers/rewrite.py
+++ b/backend/app/routers/rewrite.py
@@ -154,6 +154,7 @@ async def parse(
                 instruction=req.instruction,
                 system_prompt=profile.system_prompt_parse,
                 max_tokens=req.max_tokens,
+                api_key=req.api_key,
             ),
         )
     except HTTPException:
@@ -197,6 +198,7 @@ async def parse_stream(
                 instruction=req.instruction,
                 system_prompt=profile.system_prompt_parse,
                 max_tokens=req.max_tokens,
+                api_key=req.api_key,
             )
             async for kind, text in stream:
                 if await request.is_disconnected():
@@ -338,6 +340,7 @@ async def chat(
                 reasoning_effort=req.reasoning_effort,
                 system_prompt=profile.system_prompt_chat if profile else None,
                 max_tokens=req.max_tokens,
+                api_key=req.api_key,
             ),
         )
     except HTTPException:
@@ -398,6 +401,7 @@ async def chat_stream(
                 reasoning_effort=req.reasoning_effort,
                 system_prompt=profile.system_prompt_chat if profile else None,
                 max_tokens=req.max_tokens,
+                api_key=req.api_key,
             )
             async for kind, text in stream:
                 if await request.is_disconnected():

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -92,6 +92,7 @@ class ParseRequest(BaseModel):
     reasoning_effort: str | None = None
     instruction: str | None = Field(default=None, max_length=2000)
     max_tokens: int | None = None
+    api_key: str | None = None
 
 
 class ParseResponse(BaseModel):
@@ -205,6 +206,7 @@ class ChatRequest(BaseModel):
     model: str
     reasoning_effort: str | None = None
     max_tokens: int | None = None
+    api_key: str | None = None
 
 
 class ChatResponse(BaseModel):

--- a/frontend/src/components/LibraryTab.navigation.test.tsx
+++ b/frontend/src/components/LibraryTab.navigation.test.tsx
@@ -57,6 +57,7 @@ const stubContext: AppShellContext = {
   savedModels: [],
   onOpenSettings: vi.fn(),
   isPremium: false,
+  isAdmin: false,
   provider: '',
   model: '',
   onSave: vi.fn(),

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -27,8 +27,9 @@ export default function SettingsPage() {
     reasoningEffort,
     onChangeReasoningEffort,
     isPremium,
+    isAdmin,
   } = ctx;
-  const extraTabs = getExtraSettingsTabs(isPremium);
+  const extraTabs = getExtraSettingsTabs(isPremium, isAdmin);
   const ossTabs = showOssSettingsTabs(isPremium) ? [...SETTINGS_TABS] : [];
   const visibleTabs = [...extraTabs, ...ossTabs];
   const defaultTab = visibleTabs[0]?.key ?? 'models';

--- a/frontend/src/extensions/settings.tsx
+++ b/frontend/src/extensions/settings.tsx
@@ -5,7 +5,7 @@ export interface ExtensionTab {
   label: string;
 }
 
-export function getExtraSettingsTabs(_isPremium: boolean): ExtensionTab[] {
+export function getExtraSettingsTabs(_isPremium: boolean, _isAdmin: boolean): ExtensionTab[] {
   return [];
 }
 

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -617,6 +617,8 @@ export interface components {
             reasoning_effort?: string | null;
             /** Max Tokens */
             max_tokens?: number | null;
+            /** Api Key */
+            api_key?: string | null;
         };
         /** ChatResponse */
         ChatResponse: {
@@ -679,6 +681,8 @@ export interface components {
             instruction?: string | null;
             /** Max Tokens */
             max_tokens?: number | null;
+            /** Api Key */
+            api_key?: string | null;
         };
         /** ParseResponse */
         ParseResponse: {

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -52,6 +52,7 @@ export interface AppShellContext {
   savedModels: ReturnType<typeof useSavedModels>['savedModels'];
   onOpenSettings: () => void;
   isPremium: boolean;
+  isAdmin: boolean;
   // Settings-specific props
   provider: string;
   model: string;
@@ -263,6 +264,7 @@ export default function AppShell() {
     savedModels,
     onOpenSettings: () => navigate('/app/settings/models'),
     isPremium,
+    isAdmin: currentAuthUser?.role === 'admin',
     provider,
     model,
     onSave: (p, m) => { setProvider(p); setModel(m); },


### PR DESCRIPTION
## Summary

OSS-side changes to support the premium admin control panel (#124 in porchsongs-premium):

- Add `api_key: str | None` field to `ParseRequest` and `ChatRequest` schemas, allowing the premium middleware to inject DB-stored provider API keys into LLM calls
- Thread `api_key` through `llm_service` kwargs builders → `acompletion(api_key=...)`
- Add `isAdmin: boolean` to `AppShellContext` and pass it to `getExtraSettingsTabs()` so the premium overlay can conditionally show the admin tab
- Regenerate OpenAPI types

No behavior change for OSS users — `api_key` defaults to `None` and is ignored when absent.

**Companion PR**: njbrake/porchsongs-premium#127

## Test plan

- [x] All 121 backend tests pass
- [x] All 115 frontend tests pass (including updated LibraryTab.navigation.test)
- [x] TypeScript strict mode typecheck passes
- [x] ESLint passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)