### PR TITLE
Remove all em dashes from codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,15 +50,15 @@ React Router (`react-router-dom`) with `BrowserRouter`. App routes live under `/
 - OSS mode: `/` redirects to `/app`
 
 Key layers:
-- **`AuthContext`** (`src/contexts/AuthContext.tsx`) — Auth state, login/logout. Wraps entire app.
-- **`AppShell`** (`src/layouts/AppShell.tsx`) — Auth-gated layout for `/app/*`. Holds app state (profile, rewrite, LLM settings) and passes to children via `useOutletContext<AppShellContext>()`.
-- **`MarketingLayout`** (`src/layouts/MarketingLayout.tsx`) — Marketing nav/footer (premium only).
+- **`AuthContext`** (`src/contexts/AuthContext.tsx`): Auth state, login/logout. Wraps entire app.
+- **`AppShell`** (`src/layouts/AppShell.tsx`): Auth-gated layout for `/app/*`. Holds app state (profile, rewrite, LLM settings) and passes to children via `useOutletContext<AppShellContext>()`.
+- **`MarketingLayout`** (`src/layouts/MarketingLayout.tsx`): Marketing nav/footer (premium only).
 
 SEO meta injection (premium): `premium/porchsongs_premium/seo.py` injects route-specific meta tags into `index.html` server-side.
 
 ### Auth
 
-Plugin architecture in `backend/app/auth/`. **OSS is auth-free** — `get_current_user` auto-creates and returns a single local user (`local@porchsongs.local`). No login required. Premium adds Google OAuth via `PREMIUM_PLUGIN` env var, overriding `get_current_user` with JWT validation. JWT tokens, refresh tokens, rate limiting, and login/logout endpoints all live in the premium layer. Every data endpoint uses `Depends(get_current_user)` with `user_id` filtering. The auth ABC (`AuthBackend`), token utilities, and rate limiter remain in OSS for premium to import.
+Plugin architecture in `backend/app/auth/`. **OSS is auth-free**: `get_current_user` auto-creates and returns a single local user (`local@porchsongs.local`). No login required. Premium adds Google OAuth via `PREMIUM_PLUGIN` env var, overriding `get_current_user` with JWT validation. JWT tokens, refresh tokens, rate limiting, and login/logout endpoints all live in the premium layer. Every data endpoint uses `Depends(get_current_user)` with `user_id` filtering. The auth ABC (`AuthBackend`), token utilities, and rate limiter remain in OSS for premium to import.
 
 ### LLM Integration
 
@@ -66,7 +66,7 @@ All LLM calls go through `any-llm-sdk`. API keys from server env vars. Two modes
 
 ### SSE Streaming
 
-Always add `Cache-Control: no-cache` and `X-Accel-Buffering: no` headers. Never use Starlette's `BaseHTTPMiddleware` for SSE — use pure ASGI middleware instead.
+Always add `Cache-Control: no-cache` and `X-Accel-Buffering: no` headers. Never use Starlette's `BaseHTTPMiddleware` for SSE. Use pure ASGI middleware instead.
 
 ### Data Model
 
@@ -96,7 +96,11 @@ Tailwind CSS v4 with `@theme` tokens in `src/index.css`:
 - **Fonts**: `font-mono` / `font-ui` from `@theme`
 - **UI primitives**: Always use components from `src/components/ui/` (`Button`, `Input`, `Card`, etc.) instead of raw HTML
 - **Class names**: Use `cn()` from `@/lib/utils` for conditional classes, not template literals
-- **Cascade layers**: All custom CSS must be inside `@layer base { ... }` — unlayered CSS silently overrides Tailwind utilities
+- **Cascade layers**: All custom CSS must be inside `@layer base { ... }`. Unlayered CSS silently overrides Tailwind utilities
+
+### Content & Copy
+
+- **Never use em dashes** (`—` or `&mdash;`) in user-facing content, comments, titles, or copy. They are a telltale sign of AI-generated text. Use periods, commas, colons, or pipes instead.
 
 ### Code Conventions
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,7 +38,7 @@ export default function App() {
       {/* Premium route elements (marketing pages, etc.) */}
       {getPremiumRouteElements()}
 
-      {/* Login — OSS redirects to /app, premium renders its LoginPage */}
+      {/* Login: OSS redirects to /app, premium renders its LoginPage */}
       <Route path="/app/login" element={getLoginPageElement()} />
 
       {/* Authenticated app */}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -73,7 +73,7 @@ function _throwApiError(error: unknown, fallback: string): never {
   throw new Error(message);
 }
 
-// --- SSE streaming (stays manual — openapi-fetch doesn't handle SSE) ---
+// --- SSE streaming (stays manual, openapi-fetch doesn't handle SSE) ---
 
 async function _streamSse<T>(
   endpoint: string,
@@ -193,7 +193,7 @@ const api = {
     return data as { parse: string; chat: string };
   },
 
-  // Parse (SSE — stays manual)
+  // Parse (SSE, stays manual)
   parseStream: (
     data: Record<string, unknown>,
     onToken: (token: string) => void,
@@ -258,7 +258,7 @@ const api = {
     return data as SongRevision[];
   },
 
-  // Chat (SSE — stays manual)
+  // Chat (SSE, stays manual)
   chatStream: (
     data: Record<string, unknown>,
     onToken: (token: string) => void,
@@ -319,7 +319,7 @@ const api = {
     if (error) _throwApiError(error, 'Failed to delete connection');
   },
 
-  // PDF — uses UUID
+  // PDF (uses UUID)
   downloadSongPdf: async (songUuid: string, title: string | null, artist: string | null) => {
     const filename = `${title || 'Untitled'} - ${artist || 'Unknown'}.pdf`;
     let res = await fetch(`/api/songs/${songUuid}/pdf`, { headers: _getAuthHeaders() });

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -50,7 +50,7 @@ export default function Header({ user, authRequired, onLogout, isPremium }: Head
                 : 'bg-black/5 border-border opacity-70 hover:opacity-100'
             )}
             onClick={wakeLock.toggle}
-            title={wakeLock.active ? 'Screen staying awake — click to disable' : 'Keep screen awake while viewing song'}
+            title={wakeLock.active ? 'Screen staying awake, click to disable' : 'Keep screen awake while viewing song'}
           >
             Stay Awake
           </button>

--- a/frontend/src/components/LibraryTab.folder.test.tsx
+++ b/frontend/src/components/LibraryTab.folder.test.tsx
@@ -4,7 +4,7 @@ import LibraryTab from '@/components/LibraryTab';
 import type { AppShellContext } from '@/layouts/AppShell';
 import type { Song, ChatMessage, SavedModel } from '@/types';
 
-// Mock react-router-dom — provide useOutletContext + useParams
+// Mock react-router-dom: provide useOutletContext + useParams
 const mockOutletContext: Partial<AppShellContext> = {};
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
@@ -126,7 +126,7 @@ describe('LibraryTab folder pills', () => {
     expect(screen.getByText('Song A')).toBeInTheDocument();
     expect(screen.getByText('Song B')).toBeInTheDocument();
 
-    // The dropdown menu should NOT appear — no "Rename" or "Delete folder" visible
+    // The dropdown menu should NOT appear: no "Rename" or "Delete folder" visible
     expect(screen.queryByText('Rename')).not.toBeInTheDocument();
     expect(screen.queryByText('Delete folder')).not.toBeInTheDocument();
   });

--- a/frontend/src/components/LibraryTab.tsx
+++ b/frontend/src/components/LibraryTab.tsx
@@ -485,7 +485,7 @@ export default function LibraryTab() {
         setRevisions([]);
       }
     } else if (initialSongRef == null) {
-      // URL changed to /app/library (no song id) — return to list view
+      // URL changed to /app/library (no song id), return to list view
       setViewingSong(null);
     }
   }, [initialSongRef, loaded, songs]);
@@ -774,7 +774,7 @@ export default function LibraryTab() {
                 <h4 className="text-sm text-muted-foreground mb-2">Revision History ({revisions.length} versions)</h4>
                 {revisions.map(rev => (
                   <div key={rev.id} className="text-xs py-1 text-muted-foreground border-b border-border last:border-b-0">
-                    v{rev.version} &mdash; {rev.edit_type === 'chat' ? 'Chat edit' : 'Full rewrite'} &mdash; {rev.changes_summary || 'No summary'} &mdash; {new Date(rev.created_at).toLocaleString()}
+                    v{rev.version} · {rev.edit_type === 'chat' ? 'Chat edit' : 'Full rewrite'} · {rev.changes_summary || 'No summary'} · {new Date(rev.created_at).toLocaleString()}
                   </div>
                 ))}
               </div>

--- a/frontend/src/components/RewriteTab.test.tsx
+++ b/frontend/src/components/RewriteTab.test.tsx
@@ -3,7 +3,7 @@ import RewriteTab from '@/components/RewriteTab';
 import type { AppShellContext } from '@/layouts/AppShell';
 import type { ChatMessage, SavedModel } from '@/types';
 
-// Mock react-router-dom — provide useOutletContext
+// Mock react-router-dom: provide useOutletContext
 const mockOutletContext: Partial<AppShellContext> = {};
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
@@ -170,7 +170,7 @@ describe('RewriteTab', () => {
     const sampleLink = screen.getByText('When the Saints Go Marching In');
     expect(sampleLink).toBeInTheDocument();
 
-    // Click the sample — should skip to parsed state (chat panel + content)
+    // Click the sample: should skip to parsed state (chat panel + content)
     fireEvent.click(sampleLink);
 
     await waitFor(() => {

--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -225,7 +225,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
 
   const handleChatUpdate = useCallback((newContent: string) => {
     if (!rewriteResult && parseResult) {
-      // First chat edit — transition to WORKSHOPPING
+      // First chat edit: transition to WORKSHOPPING
       onNewRewrite(
         {
           original_content: parsedContent,
@@ -304,10 +304,10 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
 
   const handleOriginalContentUpdated = useCallback((newOriginal: string) => {
     if (!rewriteResult && parseResult) {
-      // PARSED state — update the editable parsed content
+      // PARSED state: update the editable parsed content
       setParsedContent(newOriginal);
     } else if (rewriteResult) {
-      // WORKSHOPPING state — update the original in the rewrite result
+      // WORKSHOPPING state: update the original in the rewrite result
       onNewRewrite(
         { ...rewriteResult, original_content: newOriginal },
         rewriteMeta,
@@ -487,7 +487,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
                 className="flex-1 min-h-0 resize-none"
                 value={input}
                 onChange={e => setInput(e.target.value)}
-                placeholder="Paste your lyrics and chords here — any format works"
+                placeholder="Paste your lyrics and chords here. Any format works."
                 onKeyDown={e => {
                   if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && canParse) {
                     e.preventDefault();
@@ -500,7 +500,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
                 rows={2}
                 value={instruction}
                 onChange={e => setInstruction(e.target.value)}
-                placeholder="Optional instructions — e.g. &quot;only grab the first song&quot; or &quot;skip the intro&quot;"
+                placeholder="Optional instructions, e.g. &quot;only grab the first song&quot; or &quot;skip the intro&quot;"
                 className="mt-3 font-ui"
                 onKeyDown={e => {
                   if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && canParse) {
@@ -563,7 +563,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
         <div className="flex flex-col flex-1 min-h-0 mt-2 md:mt-0">
           {mobilePaneToggle}
 
-          {/* Unified toolbar — desktop only */}
+          {/* Unified toolbar (desktop only) */}
           <div className="hidden md:flex items-center gap-4 px-4 py-2.5 border-b border-border">
             {compactTitleArtist(isWorkshopping)}
             <div className="flex items-center gap-1.5 ml-auto shrink-0">

--- a/frontend/src/components/ui/resizable-columns.tsx
+++ b/frontend/src/components/ui/resizable-columns.tsx
@@ -102,7 +102,7 @@ export default function ResizableColumns({
         {left}
       </div>
 
-      {/* Drag handle — hidden on mobile */}
+      {/* Drag handle (hidden on mobile) */}
       <div
         className="hidden md:flex justify-center w-3 cursor-col-resize select-none shrink-0 group touch-none"
         onPointerDown={onPointerDown}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -29,10 +29,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .then((config) => {
         setAuthConfig(config);
         if (!config.required) {
-          // OSS mode — no auth needed, immediately ready
+          // OSS mode: no auth needed, immediately ready
           setAuthState('ready');
         } else {
-          // Premium mode — try to restore existing session with timeout
+          // Premium mode: try to restore existing session with timeout
           const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), 10_000));
           Promise.race([api.tryRestoreSession(), timeout]).then((user) => {
             if (user) {

--- a/frontend/src/extensions/api.ts
+++ b/frontend/src/extensions/api.ts
@@ -1,5 +1,5 @@
 export async function tryRestoreSession(): Promise<null> {
-  // OSS mode — no session to restore. Premium overrides this.
+  // OSS mode: no session to restore. Premium overrides this.
   return null;
 }
 

--- a/frontend/src/extensions/quota.tsx
+++ b/frontend/src/extensions/quota.tsx
@@ -1,4 +1,4 @@
-/** OSS stub — premium overlay replaces this with real quota UI. */
+/** OSS stub: premium overlay replaces this with real quota UI. */
 
 export function QuotaBanner(): null {
   return null;

--- a/frontend/src/extensions/routes.tsx
+++ b/frontend/src/extensions/routes.tsx
@@ -6,7 +6,7 @@ export function getPremiumRouteElements(): ReactNode {
 }
 
 export function getLoginPageElement(): ReactNode {
-  // OSS has no login — redirect to app
+  // OSS has no login, redirect to app
   return <Navigate to="/app" replace />;
 }
 

--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { renderWithRouter } from '@/test/test-utils';
 
-// Mock auth context — ready state with no auth required
+// Mock auth context: ready state with no auth required
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
     authState: 'ready',

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -89,7 +89,7 @@ export default function AppShell() {
   const [rewriteMeta, setRewriteMeta] = useState<RewriteMeta | null>(null);
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
 
-  // Track current song — integer ID for chat requests, UUID for URL routing
+  // Track current song: integer ID for chat requests, UUID for URL routing
   const [currentSongId, setCurrentSongIdRaw] = useState<number | null>(null);
   const [currentSongUuid, setCurrentSongUuidRaw] = useState<string | null>(() => {
     return localStorage.getItem(STORAGE_KEYS.CURRENT_SONG_ID) || null;

--- a/frontend/src/lib/streamParser.ts
+++ b/frontend/src/lib/streamParser.ts
@@ -79,7 +79,7 @@ export class StreamParser {
       return { chatDelta: '', contentDelta: '', originalSongDelta: '' };
     }
 
-    // Buffer doesn't match — flush buffer to chat
+    // Buffer doesn't match, flush buffer to chat
     const flushed = this.tagBuffer;
     this.tagBuffer = '';
 
@@ -164,7 +164,7 @@ export class StreamParser {
       return { chatDelta: '', contentDelta: '', originalSongDelta: '' };
     }
 
-    // Buffer doesn't match — flush to chat
+    // Buffer doesn't match, flush to chat
     const flushed = this.tagBuffer;
     this.tagBuffer = '';
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,6 +1,6 @@
 import type { components } from '@/generated/api';
 
-// --- Backend types (derived from OpenAPI spec — single source of truth) ---
+// --- Backend types (derived from OpenAPI spec, single source of truth) ---
 
 export type Profile = components['schemas']['ProfileOut'];
 export type Song = components['schemas']['SongOut'];
@@ -22,7 +22,7 @@ export type ChatResult = components['schemas']['ChatResponse'];
 export type ProviderInfo = components['schemas']['ProviderInfo'];
 export type ProvidersResponse = components['schemas']['ProvidersResponse'];
 
-// --- Frontend-only types (no backend equivalent — stay manual) ---
+// --- Frontend-only types (no backend equivalent, stay manual) ---
 
 export interface RewriteResult {
   original_content: string;


### PR DESCRIPTION
## Description

Removes all em dashes (`—`) from the OSS codebase. Em dashes are a well-known marker of AI-generated text. This PR replaces every instance across:

- **User-facing content** (4 instances): placeholder text, tooltips, revision display separators
- **Code comments** (~20 instances): replaced with commas, colons, or parentheses
- **CLAUDE.md**: replaced em dashes in docs + added "Content & Copy" guideline to prevent reintroduction

17 files changed, all mechanical find-and-replace.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

**Any Additional AI Details you'd like to share:** Used to search for all em dash instances and replace them.

- [x] I am an AI Agent filling out this form (check box if true)