### PR TITLE
feat: add Report issue link to app footer

### DIFF
--- a/frontend/src/extensions/index.ts
+++ b/frontend/src/extensions/index.ts
@@ -5,6 +5,7 @@ export {
   getDefaultSettingsTab,
   shouldRedirectRootToApp,
   getFeatureRequestUrl,
+  getReportIssueUrl,
 } from './routes';
 export {
   getExtraSettingsTabs,

--- a/frontend/src/extensions/routes.tsx
+++ b/frontend/src/extensions/routes.tsx
@@ -21,3 +21,7 @@ export function shouldRedirectRootToApp(_isPremium: boolean): boolean {
 export function getFeatureRequestUrl(): string {
   return 'https://github.com/njbrake/porchsongs/issues/new?title=Feature+request:+&labels=enhancement';
 }
+
+export function getReportIssueUrl(): string {
+  return 'https://github.com/njbrake/porchsongs/issues/new?title=Bug:+&labels=bug';
+}

--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -84,4 +84,12 @@ describe('AppShell layout', () => {
     expect(link).toHaveAttribute('href');
     expect(link).toHaveAttribute('target', '_blank');
   });
+
+  it('renders report issue link in footer', () => {
+    renderWithRouter(<AppShell />, { route: '/app/rewrite' });
+
+    const link = screen.getByRole('link', { name: /report issue/i });
+    expect(link).toHaveAttribute('href');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
 });

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -10,7 +10,7 @@ import Header from '@/components/Header';
 import Tabs from '@/components/Tabs';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/AuthContext';
-import { getFeatureRequestUrl } from '@/extensions';
+import { getFeatureRequestUrl, getReportIssueUrl } from '@/extensions';
 import type { Profile, RewriteResult, RewriteMeta, ChatMessage, ChatHistoryRow, Song } from '@/types';
 
 function chatHistoryToMessages(rows: ChatHistoryRow[]): ChatMessage[] {
@@ -295,6 +295,14 @@ export default function AppShell() {
         <div className="flex items-center justify-center sm:justify-between max-w-[1800px] w-full mx-auto">
           <span className="hidden sm:inline">Made with ❤️ from open source</span>
           <div className="flex items-center gap-3">
+            <a
+              href={getReportIssueUrl()}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Report issue
+            </a>
             <a
               href={getFeatureRequestUrl()}
               target="_blank"


### PR DESCRIPTION
## Description

Adds a "Report issue" link in the app footer alongside the existing "Feature request" link. In OSS mode, it links to GitHub Issues with the `bug` label pre-filled. The premium overlay overrides this to open a `mailto:support@porchsongs.ai` link instead.

This is the OSS companion to njbrake/porchsongs-premium#190.

Fixes #169 (via premium PR njbrake/porchsongs-premium#190)

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)