### PR TITLE
fix: store first-time user status at account level

### DIFF
--- a/frontend/src/components/RewriteTab.test.tsx
+++ b/frontend/src/components/RewriteTab.test.tsx
@@ -14,12 +14,14 @@ vi.mock('react-router-dom', async () => {
 vi.mock('@/api', () => ({
   default: {
     parseStream: vi.fn(),
+    listSongs: vi.fn().mockResolvedValue([]),
   },
   STORAGE_KEYS: {
     DRAFT_INPUT: 'test_draft_input',
     DRAFT_INSTRUCTION: 'test_draft_instruction',
     SPLIT_PERCENT: 'test_split_pct',
     CURRENT_SONG_ID: 'test_current_song_id',
+    HAS_REWRITTEN: 'test_has_rewritten',
   },
 }));
 
@@ -193,7 +195,7 @@ describe('RewriteTab', () => {
     expect(sampleText.compareDocumentPosition(textarea) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  it('shows "Or try a sample" below textarea for returning users', () => {
+  it('shows "Or try a sample" below textarea for returning users (localStorage)', () => {
     localStorage.setItem(STORAGE_KEYS.HAS_REWRITTEN, '1');
     const props = makeProps();
     render(<RewriteTab {...props} />);
@@ -202,6 +204,22 @@ describe('RewriteTab', () => {
     const textarea = screen.getByPlaceholderText(/Paste your lyrics/);
 
     // Sample prompt should appear after the textarea in the DOM
+    expect(sampleText.compareDocumentPosition(textarea) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
+  });
+
+  it('shows "Or try a sample" when server reports existing songs (cross-browser)', async () => {
+    // No localStorage set, but the server returns songs for this profile
+    vi.mocked(api.listSongs).mockResolvedValueOnce([{ id: 1 }] as never);
+    const props = makeProps();
+    render(<RewriteTab {...props} />);
+
+    // After the async listSongs resolves, the UI should switch to returning-user mode
+    await waitFor(() => {
+      expect(screen.getByText(/Or try a sample/)).toBeInTheDocument();
+    });
+
+    const sampleText = screen.getByText(/Or try a sample/);
+    const textarea = screen.getByPlaceholderText(/Paste your lyrics/);
     expect(sampleText.compareDocumentPosition(textarea) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
   });
 });

--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -102,7 +102,23 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
   const [songArtist, setSongArtist] = useState('');
   const [scrapDialogOpen, setScrapDialogOpen] = useState(false);
   const [showOriginal, setShowOriginal] = useState(false);
-  const isFirstTime = !localStorage.getItem(STORAGE_KEYS.HAS_REWRITTEN);
+  const [hasSongs, setHasSongs] = useState(
+    () => !!localStorage.getItem(STORAGE_KEYS.HAS_REWRITTEN),
+  );
+
+  // Check server for existing songs when localStorage has no record.
+  // This handles the cross-browser case: user created songs on another device.
+  useEffect(() => {
+    if (hasSongs || !profile?.id) return;
+    api.listSongs(profile.id).then(songs => {
+      if (songs.length > 0) {
+        localStorage.setItem(STORAGE_KEYS.HAS_REWRITTEN, '1');
+        setHasSongs(true);
+      }
+    }).catch(() => {});
+  }, [hasSongs, profile?.id]);
+
+  const isFirstTime = !hasSongs;
 
   // Parse state
   const [parseResult, setParseResult] = useState<ParseResult | null>(null);
@@ -223,6 +239,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
       llm_model: llmSettings.model,
     });
     localStorage.setItem(STORAGE_KEYS.HAS_REWRITTEN, '1');
+    setHasSongs(true);
     onSongSaved(song);
     return song.id;
   }, [profile, songTitle, songArtist, parsedContent, llmSettings, onSongSaved]);


### PR DESCRIPTION
## Description

The "first time user" tip (showing "Start with a sample" above the textarea) was stored only in localStorage, so logging in from a different browser would show the onboarding message again as if the user had never used the app.

Now RewriteTab checks `api.listSongs()` on mount when localStorage has no record. If the server reports existing songs, the user is recognized as a returning user. localStorage still serves as a fast cache so subsequent visits within the same browser are instant with no extra API call.

Fixes #144

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)