### PR TITLE
feat: add astral ty type checker and fix all type errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: ty
+        name: ty type check
+        language: system
+        entry: uv run ty check
+        pass_filenames: false
+        files: ^backend/.*\.py$
+
       - id: openapi-types
         name: openapi types freshness
         language: system

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -79,7 +79,7 @@ class CacheHeadersMiddleware:
         await self.app(scope, receive, send_with_cache)
 
 
-app.add_middleware(CacheHeadersMiddleware)
+app.add_middleware(CacheHeadersMiddleware)  # type: ignore[arg-type]
 
 # Serve the React build output (frontend/dist) if it exists, otherwise serve frontend/ directly.
 frontend_dist = Path(__file__).resolve().parent.parent.parent / "frontend" / "dist"

--- a/backend/app/routers/rewrite.py
+++ b/backend/app/routers/rewrite.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable
 from typing import TypeVar
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -70,7 +70,7 @@ def _format_llm_error(e: Exception, provider: str | None = None) -> str:
 T = TypeVar("T")
 
 
-async def _cancellable(request: Request, coro: asyncio.Future[T]) -> T:
+async def _cancellable(request: Request, coro: Awaitable[T]) -> T:
     """Run *coro* but cancel it if the client disconnects."""
     task = asyncio.ensure_future(coro)
 

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -3,21 +3,20 @@ from __future__ import annotations
 import os
 import re
 from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from any_llm import LLMProvider, acompletion, alist_models
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from any_llm.types.completion import ChatCompletion, ChatCompletionChunk
 
     from ..models import Song
+    from ..schemas import ProviderInfo
 
 
-def _get_content(response: ChatCompletion | Iterator[ChatCompletionChunk]) -> str:
+def _get_content(response: ChatCompletion) -> str:
     """Extract text content from a completion response, raising on empty."""
-    content = response.choices[0].message.content  # type: ignore[union-attr]
+    content = response.choices[0].message.content
     if content is None:
         raise ValueError("LLM returned empty response")
     return content
@@ -128,10 +127,12 @@ def is_platform_enabled() -> bool:
     return bool(os.getenv("ANY_LLM_KEY"))
 
 
-def get_configured_providers() -> list[dict[str, object]]:
+def get_configured_providers() -> list[ProviderInfo]:
     """Return all known providers. Actual validation happens when listing models."""
+    from ..schemas import ProviderInfo
+
     return [
-        {"name": p.value, "local": p.value in _LOCAL_PROVIDERS}
+        ProviderInfo(name=p.value, local=p.value in _LOCAL_PROVIDERS)
         for p in LLMProvider
         if p.value not in _HIDDEN_PROVIDERS
     ]
@@ -139,7 +140,7 @@ def get_configured_providers() -> list[dict[str, object]]:
 
 async def get_models(provider: str, api_base: str | None = None) -> list[str]:
     """Fetch available models for a provider using env-var credentials."""
-    kwargs: dict[str, str] = {"provider": provider}
+    kwargs: dict[str, Any] = {"provider": provider}
     if api_base:
         kwargs["api_base"] = api_base
     raw = await alist_models(**kwargs)
@@ -156,14 +157,14 @@ def _build_parse_kwargs(
     system_prompt: str | None = None,
     max_tokens: int | None = None,
     api_key: str | None = None,
-) -> dict[str, object]:
+) -> dict[str, Any]:
     """Build the common kwargs dict for parse LLM calls."""
     user_text = "Clean up this pasted input. Identify the title and artist."
     if instruction:
         user_text += f"\n\nUSER INSTRUCTIONS:\n{instruction}"
     user_text += f"\n\nPASTED INPUT:\n{content}"
 
-    kwargs: dict[str, object] = {
+    kwargs: dict[str, Any] = {
         "model": model,
         "provider": provider,
         "messages": [
@@ -187,7 +188,7 @@ def _build_parse_kwargs(
 
 def _get_reasoning(response: ChatCompletion) -> str | None:
     """Extract reasoning content from a completion response, if present."""
-    msg = response.choices[0].message  # type: ignore[union-attr]
+    msg = response.choices[0].message
     reasoning = getattr(msg, "reasoning", None)
     if reasoning is not None:
         reasoning_content = getattr(reasoning, "content", None)
@@ -206,10 +207,10 @@ async def parse_content(
     system_prompt: str | None = None,
     max_tokens: int | None = None,
     api_key: str | None = None,
-) -> dict[str, str | None]:
+) -> dict[str, Any]:
     """Clean up raw pasted content and identify title/artist (non-streaming).
 
-    Returns dict with: original_content, title, artist, reasoning
+    Returns dict with: original_content, title, artist, reasoning, usage
     """
     kwargs = _build_parse_kwargs(
         content,
@@ -222,7 +223,7 @@ async def parse_content(
         max_tokens,
         api_key,
     )
-    clean_response = await acompletion(**kwargs)
+    clean_response = cast("ChatCompletion", await acompletion(**kwargs))
     clean_result = _parse_clean_response(_get_content(clean_response), content)
     reasoning = _get_reasoning(clean_response)
     usage = _get_usage(clean_response)
@@ -264,14 +265,14 @@ async def parse_content_stream(
     )
     if provider == "openai":
         kwargs["stream_options"] = {"include_usage": True}
-    response = await acompletion(stream=True, **kwargs)
+    response = cast("AsyncIterator[ChatCompletionChunk]", await acompletion(stream=True, **kwargs))
 
     import json
 
     async for chunk in response:
-        if not chunk.choices:  # type: ignore[union-attr]
+        if not chunk.choices:
             continue
-        delta = chunk.choices[0].delta  # type: ignore[union-attr]
+        delta = chunk.choices[0].delta
         if delta:
             reasoning = getattr(delta, "reasoning", None)
             if reasoning is not None:
@@ -378,12 +379,12 @@ def _build_chat_kwargs(
     system_prompt: str | None = None,
     max_tokens: int | None = None,
     api_key: str | None = None,
-) -> dict[str, object]:
+) -> dict[str, Any]:
     """Build the common kwargs dict for chat LLM calls."""
     system_content = system_prompt or CHAT_SYSTEM_PROMPT
     system_content += "\n\nORIGINAL SONG:\n" + song.original_content
 
-    llm_messages: list[dict[str, object]] = [{"role": "system", "content": system_content}]
+    llm_messages: list[dict[str, Any]] = [{"role": "system", "content": system_content}]
     for msg in messages:
         content = msg["content"]
         # Skip messages with empty content - LLM providers reject them.
@@ -393,7 +394,7 @@ def _build_chat_kwargs(
             continue
         llm_messages.append({"role": msg["role"], "content": content})
 
-    kwargs: dict[str, object] = {
+    kwargs: dict[str, Any] = {
         "model": model,
         "provider": provider,
         "messages": llm_messages,
@@ -422,7 +423,7 @@ async def chat_edit_content(
     system_prompt: str | None = None,
     max_tokens: int | None = None,
     api_key: str | None = None,
-) -> dict[str, str | None]:
+) -> dict[str, Any]:
     """Process a chat-based content edit (non-streaming).
 
     Builds system context with original + current content and the conversation history,
@@ -442,7 +443,7 @@ async def chat_edit_content(
         max_tokens,
         api_key,
     )
-    response = await acompletion(**kwargs)
+    response = cast("ChatCompletion", await acompletion(**kwargs))
 
     raw_response = _get_content(response)
     parsed = _parse_chat_response(raw_response)
@@ -491,14 +492,14 @@ async def chat_edit_content_stream(
     )
     if provider == "openai":
         kwargs["stream_options"] = {"include_usage": True}
-    response = await acompletion(stream=True, **kwargs)
+    response = cast("AsyncIterator[ChatCompletionChunk]", await acompletion(stream=True, **kwargs))
 
     import json
 
     async for chunk in response:
-        if not chunk.choices:  # type: ignore[union-attr]
+        if not chunk.choices:
             continue
-        delta = chunk.choices[0].delta  # type: ignore[union-attr]
+        delta = chunk.choices[0].delta
         if delta:
             reasoning = getattr(delta, "reasoning", None)
             if reasoning is not None:

--- a/backend/app/services/pdf_service.py
+++ b/backend/app/services/pdf_service.py
@@ -21,7 +21,7 @@ def _sanitize_for_latin1(text: str) -> str:
     return text.encode("latin-1", errors="replace").decode("latin-1")
 
 
-def generate_song_pdf(title: str, artist: str | None, content: str) -> bytes:
+def generate_song_pdf(title: str | None, artist: str | None, content: str) -> bytes:
     """Generate a PDF for a song with monospace content to preserve chord alignment."""
     pdf = FPDF(orientation="P", unit="mm", format="A4")
     pdf.set_auto_page_break(auto=True, margin=15)

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -1,5 +1,6 @@
 """Tests for llm_service pure functions (no LLM calls)."""
 
+from typing import Any
 from types import SimpleNamespace
 
 from app.services.llm_service import (
@@ -76,17 +77,18 @@ def test_build_chat_kwargs_system_prompt() -> None:
         {"role": "user", "content": "make it sadder"},
         {"role": "assistant", "content": "ok"},
     ]
-    kwargs = _build_chat_kwargs(song, messages, "openai", "gpt-4o")
+    kwargs = _build_chat_kwargs(song, messages, "openai", "gpt-4o")  # type: ignore[arg-type]
 
-    system_msg = kwargs["messages"][0]  # type: ignore[index]
-    assert system_msg["role"] == "system"  # type: ignore[index]
-    assert "ORIGINAL SONG" in system_msg["content"]  # type: ignore[index]
-    assert song.original_content in system_msg["content"]  # type: ignore[index]
-    assert "EDITED SONG" not in system_msg["content"]  # type: ignore[index]
+    llm_messages: list[dict[str, Any]] = kwargs["messages"]
+    system_msg = llm_messages[0]
+    assert system_msg["role"] == "system"
+    assert "ORIGINAL SONG" in system_msg["content"]
+    assert song.original_content in system_msg["content"]
+    assert "EDITED SONG" not in system_msg["content"]
 
     # User/assistant messages passed through unchanged
-    assert kwargs["messages"][1] == {"role": "user", "content": "make it sadder"}  # type: ignore[index]
-    assert kwargs["messages"][2] == {"role": "assistant", "content": "ok"}  # type: ignore[index]
+    assert llm_messages[1] == {"role": "user", "content": "make it sadder"}
+    assert llm_messages[2] == {"role": "assistant", "content": "ok"}
 
 
 def test_build_chat_kwargs_reasoning_effort_off() -> None:
@@ -96,7 +98,7 @@ def test_build_chat_kwargs_reasoning_effort_off() -> None:
         rewritten_content="G  Am\nHello changed world",
     )
     messages = [{"role": "user", "content": "make it sadder"}]
-    kwargs = _build_chat_kwargs(song, messages, "openai", "gpt-4o", reasoning_effort="off")
+    kwargs = _build_chat_kwargs(song, messages, "openai", "gpt-4o", reasoning_effort="off")  # type: ignore[arg-type]
     assert kwargs["reasoning_effort"] == "off"
 
 
@@ -107,7 +109,7 @@ def test_build_chat_kwargs_reasoning_effort_high() -> None:
         rewritten_content="G  Am\nHello changed world",
     )
     messages = [{"role": "user", "content": "make it sadder"}]
-    kwargs = _build_chat_kwargs(song, messages, "openai", "gpt-4o", reasoning_effort="high")
+    kwargs = _build_chat_kwargs(song, messages, "openai", "gpt-4o", reasoning_effort="high")  # type: ignore[arg-type]
     assert kwargs["reasoning_effort"] == "high"
 
 
@@ -130,6 +132,7 @@ def test_parse_chat_with_xml_tags() -> None:
     raw = "<content>\nHello world\nSecond line\n</content>\nI changed the first word."
     result = _parse_chat_response(raw)
     assert result["content"] == "Hello world\nSecond line"
+    assert result["explanation"] is not None
     assert "changed" in result["explanation"]
 
 

--- a/tests/test_song_uuid.py
+++ b/tests/test_song_uuid.py
@@ -38,8 +38,9 @@ def test_song_has_uuid_on_create(client: TestClient) -> None:
     assert "uuid" in song
     assert song["uuid"] is not None
     # Validate it's a proper UUID format
-    parsed = uuid.UUID(song["uuid"])
-    assert str(parsed) == song["uuid"]
+    song_uuid = str(song["uuid"])
+    parsed = uuid.UUID(song_uuid)
+    assert str(parsed) == song_uuid
 
 
 def test_each_song_gets_unique_uuid(client: TestClient) -> None:


### PR DESCRIPTION
## Description

Add [astral ty](https://github.com/astral-sh/ty) type checker to the project and fix all type errors it found. ty is already listed as a dev dependency (`>=0.0.17`) and configured in `pyproject.toml` but was not integrated into the pre-commit workflow and had outstanding type errors.

### Changes

**Type fixes in `backend/app/services/llm_service.py`:**
- Changed kwargs dict types from `dict[str, object]` to `dict[str, Any]` for `_build_parse_kwargs`, `_build_chat_kwargs`, and `get_models` (ty rejects `**kwargs` unpacking when values are typed as `object`)
- Added `cast()` to narrow `acompletion()` return types (`ChatCompletion` for non-streaming, `AsyncIterator[ChatCompletionChunk]` for streaming)
- Widened return types of `parse_content` and `chat_edit_content` from `dict[str, str | None]` to `dict[str, Any]` (they include `usage` as a nested dict)
- Simplified `_get_content` to accept only `ChatCompletion` (was never called with `Iterator`)
- Changed `get_configured_providers` to return `list[ProviderInfo]` objects instead of `list[dict[str, object]]`
- Removed unused `Iterator` import and stale `type: ignore` comments

**Type fixes in other files:**
- `rewrite.py`: Changed `_cancellable` parameter from `asyncio.Future[T]` to `Awaitable[T]`
- `main.py`: Added `type: ignore[arg-type]` for ASGI middleware (known Starlette limitation)
- `pdf_service.py`: Changed `generate_song_pdf` title param from `str` to `str | None`

**Test fixes:**
- `test_llm_service.py`: Added `type: ignore[arg-type]` for `SimpleNamespace` as `Song`, removed stale `type: ignore[index]`, added null guard before `in` operator
- `test_song_uuid.py`: Used `str()` conversion before `uuid.UUID()` call

**Pre-commit:**
- Added `ty` local hook running on `backend/**/*.py` files

Fixes #141

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** All changes were minimal type annotation fixes to satisfy ty's strict type checking. No behavioral changes.

- [x] I am an AI Agent filling out this form (check box if true)