### PR TITLE
chore: remove stale budget_tokens comments

### DIFF
--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -176,9 +176,6 @@ def _build_parse_kwargs(
         kwargs["api_base"] = api_base
     if api_key:
         kwargs["api_key"] = api_key
-    # Always pass reasoning_effort explicitly. any_llm defaults to "auto" which
-    # lets Anthropic enable extended thinking automatically — causing max_tokens
-    # vs budget_tokens conflicts. Passing None tells any_llm to disable thinking.
     kwargs["reasoning_effort"] = reasoning_effort
     from ..config import settings
 
@@ -403,9 +400,6 @@ def _build_chat_kwargs(
         kwargs["api_base"] = api_base
     if api_key:
         kwargs["api_key"] = api_key
-    # Always pass reasoning_effort explicitly. any_llm defaults to "auto" which
-    # lets Anthropic enable extended thinking automatically — causing max_tokens
-    # vs budget_tokens conflicts. Passing None tells any_llm to disable thinking.
     kwargs["reasoning_effort"] = reasoning_effort
     from ..config import settings
 


### PR DESCRIPTION
## Summary
- Remove outdated comments about `budget_tokens` conflicts in `llm_service.py`
- any-llm-sdk 1.12.x handles thinking budgets internally, so the workaround comments are no longer relevant

## Test plan
- [x] All 123 OSS backend tests pass
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)