### PR TITLE
feat: add open_signup field to AuthConfig type

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -69,4 +69,5 @@ export interface AuthConfig {
   require_invite_code?: boolean;
   magic_link_enabled?: boolean;
   github_oauth_enabled?: boolean;
+  open_signup?: boolean;
 }


### PR DESCRIPTION
## Summary
- Adds `open_signup?: boolean` to the `AuthConfig` TypeScript interface
- Companion to njbrake/porchsongs-premium PR that uses this field to make the invite code optional when open signup is active

## Test plan
- [x] `npm run typecheck` passes
- [x] All 22 LoginPage frontend tests pass
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)