### PR TITLE
fix: improve mobile responsiveness on parse screen

### DIFF
--- a/frontend/src/components/ChatPanel.test.tsx
+++ b/frontend/src/components/ChatPanel.test.tsx
@@ -83,6 +83,20 @@ describe('ChatPanel', () => {
     expect(imgs).toHaveLength(2);
   });
 
+  it('auto-scrolls via scrollTop instead of scrollIntoView', () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+    ];
+    const { container } = render(<ChatPanel {...defaults} messages={messages} />);
+    // The scroll container should exist and not contain a messagesEnd sentinel div
+    const scrollContainer = container.querySelector('.overflow-y-auto');
+    expect(scrollContainer).toBeInTheDocument();
+    // Verify no scrollIntoView sentinel element (the old messagesEndRef div)
+    const lastChild = scrollContainer!.lastElementChild;
+    expect(lastChild).not.toBeEmptyDOMElement();
+  });
+
   it('rejects images larger than 5 MB with a toast error', async () => {
     render(<ChatPanel {...defaults} />);
     const input = screen.getByPlaceholderText(/Tell the AI/);

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -46,7 +46,7 @@ function ChatMessageBubble({ msg, isStreaming }: { msg: ChatMessage; isStreaming
         <>
           <Button
             variant="link-inline"
-            className="block mb-1.5 text-xs opacity-80 hover:opacity-100"
+            className="block mb-1.5 text-xs opacity-80 can-hover:hover:opacity-100"
             onClick={() => setThinkingExpanded(prev => !prev)}
           >
             {thinkingExpanded ? 'Hide thinking' : 'Show thinking'}
@@ -75,7 +75,7 @@ function ChatMessageBubble({ msg, isStreaming }: { msg: ChatMessage; isStreaming
       {hasRaw && !isStreaming && (
         <Button
           variant="link-inline"
-          className="block mt-1.5 text-xs opacity-80 hover:opacity-100"
+          className="block mt-1.5 text-xs opacity-80 can-hover:hover:opacity-100"
           onClick={() => setExpanded(prev => !prev)}
         >
           {expanded ? 'Show summary' : 'Show full response'}
@@ -112,7 +112,7 @@ export default function ChatPanel({ songId, messages, setMessages, llmSettings, 
   const [images, setImages] = useState<AttachedImage[]>([]);
   const [dragging, setDragging] = useState(false);
   const dragCounterRef = useRef(0);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const abortRef = useRef<AbortController | null>(null);
 
   const processFiles = useCallback(async (files: FileList | File[]) => {
@@ -185,8 +185,12 @@ export default function ChatPanel({ songId, messages, setMessages, llmSettings, 
     setImages(prev => prev.filter((_, i) => i !== index));
   }, []);
 
+  // Use scrollTop instead of scrollIntoView to avoid iOS Safari viewport zoom bug
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const el = scrollContainerRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
   }, [messages, reasoningText]);
 
   // Abort any in-flight request on unmount
@@ -390,7 +394,7 @@ export default function ChatPanel({ songId, messages, setMessages, llmSettings, 
           Chat history limit reached ({MAX_MESSAGES} messages). Older messages will be dropped.
         </div>
       )}
-      <div className={cn('flex-1 overflow-y-auto p-4 flex flex-col gap-2', flat && 'md:bg-panel md:shadow-[inset_0_1px_4px_rgba(0,0,0,0.04)] md:rounded-md')}>
+      <div ref={scrollContainerRef} className={cn('flex-1 overflow-y-auto p-4 flex flex-col gap-2', flat && 'md:bg-panel md:shadow-[inset_0_1px_4px_rgba(0,0,0,0.04)] md:rounded-md')}>
         {messages.map((msg, i) => (
           <div key={i} className={cn('flex flex-col', msg.role === 'user' ? 'items-end' : 'items-start')}>
             <ChatMessageBubble msg={msg} isStreaming={streaming && i === messages.length - 1} />
@@ -423,7 +427,6 @@ export default function ChatPanel({ songId, messages, setMessages, llmSettings, 
             )}
           </div>
         )}
-        <div ref={messagesEndRef} />
       </div>
       {(tokenUsage.input_tokens > 0 || tokenUsage.output_tokens > 0) && (
         <div className="px-4 py-1.5 border-t border-border text-xs text-muted-foreground flex justify-between">
@@ -441,7 +444,7 @@ export default function ChatPanel({ songId, messages, setMessages, llmSettings, 
             <div key={idx} className="relative group">
               <img src={img.dataUrl} alt={img.name} className="h-12 w-12 rounded object-cover border border-border" />
               <button
-                className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-danger text-white text-[10px] leading-none flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-danger text-white text-[10px] leading-none flex items-center justify-center opacity-0 can-hover:group-hover:opacity-100 transition-opacity"
                 onClick={() => removeImage(idx)}
                 aria-label={`Remove ${img.name}`}
               >

--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -350,7 +350,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
     }
   }, [currentSongUuid, rewriteResult]);
 
-  const editableInputClass = 'bg-transparent border-0 border-b border-transparent hover:border-dashed hover:border-border focus:border-solid focus:border-primary p-0 pb-px min-w-0 w-full focus:outline-none cursor-text transition-colors';
+  const editableInputClass = 'bg-transparent border-0 border-b border-transparent can-hover:hover:border-dashed can-hover:hover:border-border focus:border-solid focus:border-primary p-0 pb-px min-w-0 w-full focus:outline-none cursor-text transition-colors';
 
   const compactTitleArtist = (withBlur?: boolean) => (
     <div className="flex flex-col gap-0.5 flex-1 min-w-0 max-w-sm">
@@ -512,7 +512,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
                 <>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
-                    className="text-danger hover:!bg-danger-light"
+                    className="text-danger can-hover:hover:!bg-danger-light"
                     disabled={!currentSongUuid}
                     onClick={() => setScrapDialogOpen(true)}
                   >
@@ -560,7 +560,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
                       {i > 0 && ' · '}
                       <button
                         type="button"
-                        className="text-primary font-medium underline hover:opacity-80 cursor-pointer"
+                        className="text-primary font-medium underline can-hover:hover:opacity-80 cursor-pointer"
                         onClick={() => handleLoadSample(s)}
                       >
                         {s.title}
@@ -614,7 +614,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
                       {i > 0 && ' · '}
                       <button
                         type="button"
-                        className="text-primary underline hover:opacity-80 cursor-pointer"
+                        className="text-primary underline can-hover:hover:opacity-80 cursor-pointer"
                         onClick={() => handleLoadSample(s)}
                       >
                         {s.title}
@@ -689,7 +689,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
                     <>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
-                        className="text-danger hover:!bg-danger-light"
+                        className="text-danger can-hover:hover:!bg-danger-light"
                         disabled={!currentSongUuid}
                         onClick={() => setScrapDialogOpen(true)}
                       >
@@ -743,7 +743,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
                           <>
                             <DropdownMenuSeparator />
                             <DropdownMenuItem
-                              className="text-danger hover:!bg-danger-light"
+                              className="text-danger can-hover:hover:!bg-danger-light"
                               disabled={!currentSongUuid}
                               onClick={() => setScrapDialogOpen(true)}
                             >
@@ -765,7 +765,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
                   )}
                   <div className="flex-1 min-h-[200px] bg-card shadow-[inset_0_1px_4px_rgba(0,0,0,0.04)] rounded-sm">
                     <Textarea
-                      className="h-full border-0 bg-transparent p-3 sm:p-4 font-mono text-xs sm:text-code leading-relaxed resize-none focus-visible:ring-0"
+                      className="h-full min-h-[50vh] md:min-h-0 border-0 bg-transparent p-3 sm:p-4 font-mono text-xs sm:text-code leading-relaxed resize-none focus-visible:ring-0"
                       value={parsedContent}
                       onChange={e => setParsedContent(e.target.value)}
                     />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 
+/* Hover styles only on devices that support hover (prevents sticky hover on touch) */
+@custom-variant can-hover (@media (hover: hover));
+
 @theme {
   --color-background: #fafafa;
   --color-card: #ffffff;
@@ -65,6 +68,24 @@
 @layer base {
   html {
     overflow-x: hidden;
+  }
+
+  /* Prevent iOS Safari auto-zoom on input focus (requires font-size >= 16px) */
+  @media screen and (max-width: 767px) {
+    input,
+    select,
+    textarea {
+      font-size: 16px;
+    }
+  }
+
+  /* Prevent double-tap-to-zoom on interactive elements (iOS Safari) */
+  button,
+  input,
+  select,
+  textarea,
+  a {
+    touch-action: manipulation;
   }
 
   html[data-theme="dark"] {

--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -92,4 +92,31 @@ describe('AppShell layout', () => {
     expect(link).toHaveAttribute('href');
     expect(link).toHaveAttribute('target', '_blank');
   });
+
+  it('sets maximum-scale=1 on iOS to prevent auto-zoom', () => {
+    const meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
+    if (!meta) {
+      const m = document.createElement('meta');
+      m.name = 'viewport';
+      m.content = 'width=device-width, initial-scale=1.0';
+      document.head.appendChild(m);
+    }
+
+    // Simulate iOS user agent
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X)',
+      configurable: true,
+    });
+
+    renderWithRouter(<AppShell />, { route: '/app/rewrite' });
+
+    const viewport = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
+    expect(viewport?.content).toContain('maximum-scale=1');
+
+    // Restore user agent
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (X11; Linux x86_64)',
+      configurable: true,
+    });
+  });
 });

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -109,6 +109,16 @@ export default function AppShell() {
 
   const llmSettings = { provider, model, reasoning_effort: reasoningEffort };
 
+  // Prevent iOS Safari auto-zoom on input focus.
+  // Since iOS 10, maximum-scale=1 only blocks automatic zoom (not user pinch-zoom).
+  useEffect(() => {
+    if (!/iPhone|iPad|iPod/.test(navigator.userAgent)) return;
+    const meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
+    if (meta && !meta.content.includes('maximum-scale')) {
+      meta.setAttribute('content', meta.content + ', maximum-scale=1');
+    }
+  }, []);
+
   // Load profile on mount; auto-create if none exist
   const loadProfile = useCallback(() => {
     setProfileError(false);


### PR DESCRIPTION
## Description

Fix mobile responsiveness issues on the parse/rewrite screen. Addresses iOS Safari auto-zoom on input focus, double-tap-to-zoom, sticky hover states on touch devices, viewport zoom during chat scrolling, and short textarea on mobile.

Applies proven patterns from the [clawbolt](https://github.com/mozilla-ai/clawbolt) mobile fixes.

**Changes:**
- Force 16px font on mobile inputs to prevent iOS auto-zoom (`index.css`)
- Add `touch-action: manipulation` on interactive elements (`index.css`)
- Dynamically set `maximum-scale=1` on iOS only (`AppShell.tsx`)
- Replace `scrollIntoView` with `scrollTop` to avoid iOS viewport zoom bug (`ChatPanel.tsx`)
- Add `@custom-variant can-hover` and update hover classes to prevent sticky hover on touch (`index.css`, `RewriteTab.tsx`, `ChatPanel.tsx`)
- Add `min-h-[50vh]` to parsed content textarea on mobile (`RewriteTab.tsx`)

Fixes #150

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

**Any Additional AI Details you'd like to share:** Referenced mobile-friendly patterns from mozilla-ai/clawbolt repo.

- [x] I am an AI Agent filling out this form (check box if true)