### PR TITLE
fix: restore smooth scroll animation in chat panel

### DIFF
--- a/frontend/src/components/ChatPanel.test.tsx
+++ b/frontend/src/components/ChatPanel.test.tsx
@@ -5,6 +5,9 @@ import type { ChatMessage } from '@/types';
 
 vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
 
+// jsdom doesn't implement scrollTo
+Element.prototype.scrollTo = vi.fn();
+
 describe('ChatPanel', () => {
   const defaults = {
     songId: 1,
@@ -83,18 +86,15 @@ describe('ChatPanel', () => {
     expect(imgs).toHaveLength(2);
   });
 
-  it('auto-scrolls via scrollTop instead of scrollIntoView', () => {
+  it('uses scrollTo instead of scrollIntoView for iOS compatibility', () => {
     const messages: ChatMessage[] = [
       { role: 'user', content: 'Hello' },
       { role: 'assistant', content: 'Hi there' },
     ];
     const { container } = render(<ChatPanel {...defaults} messages={messages} />);
-    // The scroll container should exist and not contain a messagesEnd sentinel div
     const scrollContainer = container.querySelector('.overflow-y-auto');
     expect(scrollContainer).toBeInTheDocument();
-    // Verify no scrollIntoView sentinel element (the old messagesEndRef div)
-    const lastChild = scrollContainer!.lastElementChild;
-    expect(lastChild).not.toBeEmptyDOMElement();
+    expect(scrollContainer!.scrollTo).toHaveBeenCalledWith({ top: expect.any(Number), behavior: 'smooth' });
   });
 
   it('rejects images larger than 5 MB with a toast error', async () => {

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -185,11 +185,11 @@ export default function ChatPanel({ songId, messages, setMessages, llmSettings, 
     setImages(prev => prev.filter((_, i) => i !== index));
   }, []);
 
-  // Use scrollTop instead of scrollIntoView to avoid iOS Safari viewport zoom bug
+  // Use scrollTo instead of scrollIntoView to avoid iOS Safari viewport zoom bug
   useEffect(() => {
     const el = scrollContainerRef.current;
     if (el) {
-      el.scrollTop = el.scrollHeight;
+      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
     }
   }, [messages, reasoningText]);
 


### PR DESCRIPTION
## Description

Follow-up to #158. The `scrollIntoView` replacement used raw `scrollTop = scrollHeight` which lost the smooth scroll animation. This switches to `scrollTo({ top: scrollHeight, behavior: 'smooth' })` which preserves the animation while still avoiding `scrollIntoView`'s viewport-level side effects on iOS Safari.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

- [x] I am an AI Agent filling out this form (check box if true)