### PR TITLE
feat: mobile paste-from-clipboard button

### DIFF
--- a/frontend/src/components/RewriteTab.test.tsx
+++ b/frontend/src/components/RewriteTab.test.tsx
@@ -231,6 +231,7 @@ describe('RewriteTab', () => {
 
   it('reads clipboard content when paste button is clicked', async () => {
     const clipboardText = '[G]Amazing [C]Grace how [D]sweet the [G]sound';
+    const originalClipboard = navigator.clipboard;
     Object.assign(navigator, {
       clipboard: { readText: vi.fn().mockResolvedValue(clipboardText) },
     });
@@ -248,9 +249,12 @@ describe('RewriteTab', () => {
 
     // Button should disappear after pasting
     expect(screen.queryByRole('button', { name: 'Paste from clipboard' })).not.toBeInTheDocument();
+
+    Object.assign(navigator, { clipboard: originalClipboard });
   });
 
   it('silently handles clipboard access denial', async () => {
+    const originalClipboard = navigator.clipboard;
     Object.assign(navigator, {
       clipboard: { readText: vi.fn().mockRejectedValue(new DOMException('Denied')) },
     });
@@ -265,6 +269,8 @@ describe('RewriteTab', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Paste from clipboard' })).toBeInTheDocument();
     });
+
+    Object.assign(navigator, { clipboard: originalClipboard });
   });
 
   it('shows "Or try a sample" when server reports existing songs (cross-browser)', async () => {

--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -584,7 +584,6 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
                   variant="secondary"
                   className="mb-3 md:hidden"
                   onClick={handlePasteFromClipboard}
-                  aria-label="Paste from clipboard"
                 >
                   Paste from clipboard
                 </Button>


### PR DESCRIPTION
## Description

On mobile, tapping the textarea to paste a chord chart opens the virtual keyboard, shrinking the screen and making the paste area harder to use. This adds a "Paste from clipboard" button (visible only on mobile via `md:hidden`) that uses the Clipboard API to populate the textarea without triggering the keyboard. The button disappears once content is present.

Fixes #162

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

**Any Additional AI Details you'd like to share:** Full implementation including tests.

- [x] I am an AI Agent filling out this form (check box if true)