### PR TITLE
fix: prevent stale closure from reverting rewritten content

### DIFF
--- a/frontend/src/components/LibraryTab.navigation.test.tsx
+++ b/frontend/src/components/LibraryTab.navigation.test.tsx
@@ -50,6 +50,7 @@ const stubContext: AppShellContext = {
   onNewRewrite: vi.fn(),
   onSongSaved: vi.fn(),
   onContentUpdated: vi.fn(),
+  onOriginalContentUpdated: vi.fn(),
   onChangeProvider: vi.fn(),
   onChangeModel: vi.fn(),
   reasoningEffort: 'high',

--- a/frontend/src/components/RewriteTab.test.tsx
+++ b/frontend/src/components/RewriteTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import RewriteTab from '@/components/RewriteTab';
 import type { AppShellContext } from '@/layouts/AppShell';
 import type { ChatMessage, SavedModel } from '@/types';
@@ -15,6 +15,7 @@ vi.mock('@/api', () => ({
   default: {
     parseStream: vi.fn(),
     listSongs: vi.fn().mockResolvedValue([]),
+    updateSong: vi.fn().mockResolvedValue({}),
   },
   STORAGE_KEYS: {
     DRAFT_INPUT: 'test_draft_input',
@@ -25,11 +26,13 @@ vi.mock('@/api', () => ({
   },
 }));
 
-// Mock heavy child components to isolate RewriteTab layout tests
+// Capture ChatPanel props so tests can invoke the callbacks RewriteTab passes in
+let capturedChatPanelProps: Record<string, unknown> = {};
 vi.mock('@/components/ChatPanel', () => ({
-  default: ({ headerRight }: { headerRight?: React.ReactNode }) => (
-    <div data-testid="chat-panel">{headerRight}</div>
-  ),
+  default: (props: Record<string, unknown>) => {
+    capturedChatPanelProps = props;
+    return <div data-testid="chat-panel">{props.headerRight as React.ReactNode}</div>;
+  },
 }));
 vi.mock('@/components/ComparisonView', () => ({ default: () => <div data-testid="comparison-view" /> }));
 vi.mock('@/components/ui/resizable-columns', () => ({
@@ -55,6 +58,7 @@ function makeProps(overrides: Partial<AppShellContext> = {}): AppShellContext {
     onNewRewrite: vi.fn(),
     onSongSaved: vi.fn(),
     onContentUpdated: vi.fn(),
+    onOriginalContentUpdated: vi.fn(),
     onChangeProvider: vi.fn(),
     onChangeModel: vi.fn(),
     reasoningEffort: 'high',
@@ -287,5 +291,46 @@ describe('RewriteTab', () => {
     const sampleText = screen.getByText(/Or try a sample/);
     const textarea = screen.getByPlaceholderText(/Paste your lyrics/);
     expect(sampleText.compareDocumentPosition(textarea) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
+  });
+
+  it('does not revert rewritten content when original content is updated in the same batch (issue #165)', () => {
+    // Setup: workshopping state with known content
+    const onNewRewrite = vi.fn();
+    const onContentUpdated = vi.fn();
+
+    render(<RewriteTab {...makeProps({
+      rewriteResult: {
+        original_content: 'original lyrics',
+        rewritten_content: 'old rewritten lyrics',
+        changes_summary: 'Initial',
+      },
+      rewriteMeta: { title: 'Test', artist: 'Artist' },
+      currentSongId: 42,
+      currentSongUuid: 'test-uuid-42',
+      onNewRewrite,
+      onContentUpdated,
+    })} />);
+
+    // Simulate what ChatPanel does after streaming a response that contains
+    // both <content> and <original_song> tags. ChatPanel calls onContentUpdated
+    // first, then onOriginalContentUpdated (see ChatPanel.tsx lines 354-358).
+    const chatOnContent = capturedChatPanelProps.onContentUpdated as (s: string) => void;
+    const chatOnOriginal = capturedChatPanelProps.onOriginalContentUpdated as (s: string) => void;
+
+    act(() => {
+      chatOnContent('NEW rewritten lyrics');
+      chatOnOriginal('NEW original lyrics');
+    });
+
+    // The original content update must NOT clobber the new rewritten content.
+    // Bug: handleOriginalContentUpdated spreads a stale rewriteResult closure
+    // that still has 'old rewritten lyrics', overwriting the update from
+    // onContentUpdated.
+    for (const call of onNewRewrite.mock.calls) {
+      const result = call[0] as { rewritten_content: string } | null;
+      if (result !== null) {
+        expect(result.rewritten_content).not.toBe('old rewritten lyrics');
+      }
+    }
   });
 });

--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -45,6 +45,7 @@ interface RewriteTabProps {
   onNewRewrite: (result: RewriteResult | null, meta: RewriteMeta | null) => void;
   onSongSaved: (song: Song) => void;
   onContentUpdated: (content: string) => void;
+  onOriginalContentUpdated: (content: string) => void;
   onChangeProvider: (provider: string) => void;
   onChangeModel: (model: string) => void;
   reasoningEffort: string;
@@ -69,6 +70,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
     onNewRewrite,
     onSongSaved,
     onContentUpdated,
+    onOriginalContentUpdated: onOriginalContentUpdatedCtx,
     onChangeProvider,
     onChangeModel,
     reasoningEffort,
@@ -336,18 +338,17 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
     if (!rewriteResult && parseResult) {
       // PARSED state: update the editable parsed content
       setParsedContent(newOriginal);
-    } else if (rewriteResult) {
-      // WORKSHOPPING state: update the original in the rewrite result
-      onNewRewrite(
-        { ...rewriteResult, original_content: newOriginal },
-        rewriteMeta,
-      );
+    } else {
+      // WORKSHOPPING state: use functional updater to avoid stale closure.
+      // Spreading rewriteResult here would clobber concurrent rewritten_content
+      // updates from onContentUpdated (issue #165).
+      onOriginalContentUpdatedCtx(newOriginal);
     }
     // Persist to DB
     if (currentSongUuid) {
       api.updateSong(currentSongUuid, { original_content: newOriginal } as Partial<Song>).catch(() => {});
     }
-  }, [rewriteResult, parseResult, rewriteMeta, currentSongUuid, onNewRewrite]);
+  }, [rewriteResult, parseResult, currentSongUuid, onOriginalContentUpdatedCtx]);
 
   const handleRewrittenChange = useCallback((newText: string) => {
     onContentUpdated(newText);

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -45,6 +45,7 @@ export interface AppShellContext {
   onNewRewrite: (result: RewriteResult | null, meta: RewriteMeta | null) => void;
   onSongSaved: (song: Song) => void;
   onContentUpdated: (content: string) => void;
+  onOriginalContentUpdated: (content: string) => void;
   onChangeProvider: (provider: string) => void;
   onChangeModel: (model: string) => void;
   reasoningEffort: string;
@@ -199,6 +200,10 @@ export default function AppShell() {
     setRewriteResult(prev => prev ? { ...prev, rewritten_content: newContent } : prev);
   }, []);
 
+  const handleOriginalUpdated = useCallback((newOriginal: string) => {
+    setRewriteResult(prev => prev ? { ...prev, original_content: newOriginal } : prev);
+  }, []);
+
   const handleLoadSong = useCallback(async (song: Song) => {
     setRewriteResult({
       original_content: song.original_content,
@@ -267,6 +272,7 @@ export default function AppShell() {
     onNewRewrite: handleNewRewrite,
     onSongSaved: handleSongSaved,
     onContentUpdated: handleContentUpdated,
+    onOriginalContentUpdated: handleOriginalUpdated,
     onChangeProvider: setProvider,
     onChangeModel: setModel,
     reasoningEffort,


### PR DESCRIPTION
## Description

Fixes #165. When the LLM response includes both `<content>` (rewritten song) and `<original_song>` tags, `handleOriginalContentUpdated` in RewriteTab spread a stale `rewriteResult` closure into `onNewRewrite`, overwriting the new `rewritten_content` that was just set by `onContentUpdated` in the same React batch. The user would see the LLM's changes in "Show full response" but the Song view would revert to the old version.

**Root cause:** Two state updates fired in the same React batch:
1. `onContentUpdated(result.rewritten_content)` used a functional updater (correct)
2. `onOriginalContentUpdated(result.original_content)` spread a stale closure value into `onNewRewrite`, overwriting step 1

**Fix:** Added `onOriginalContentUpdated` functional-update callback to AppShell (parallel to existing `onContentUpdated`). RewriteTab now uses this instead of spreading stale closure state through `onNewRewrite`.

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)