### PR TITLE
feat: double default max output tokens to 32k

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -8,7 +8,7 @@ class Settings(BaseSettings):
     jwt_expiry_minutes: int = 15
     refresh_token_days: int = 30
     premium_plugin: str | None = None
-    default_max_tokens: int = 16384
+    default_max_tokens: int = 32768
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 


### PR DESCRIPTION
## Summary
- Doubles `default_max_tokens` from 16,384 to 32,768 in OSS config

## Test plan
- [ ] Verify rewrite/chat responses can use up to 32k output tokens
- [ ] Existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)