### PR TITLE
feat: migrate to Messages API with Anthropic prompt caching

### DIFF
--- a/backend/app/routers/rewrite.py
+++ b/backend/app/routers/rewrite.py
@@ -249,8 +249,12 @@ def _load_chat_messages(
     db: Session,
     song_id: int,
     req_messages: list[ChatMessage],
-) -> list[dict[str, object]]:
-    """Load persisted chat history and append new request messages."""
+) -> tuple[list[dict[str, object]], int]:
+    """Load persisted chat history and append new request messages.
+
+    Returns (all_messages, history_len) where history_len is the count of
+    messages from the database (before the new request messages).
+    """
     history_rows = (
         db.query(ChatMessageModel)
         .filter(ChatMessageModel.song_id == song_id, ChatMessageModel.is_note.is_(False))
@@ -260,7 +264,8 @@ def _load_chat_messages(
     history: list[dict[str, object]] = [
         {"role": row.role, "content": _deserialize_content(row.content)} for row in history_rows
     ]
-    return history + [{"role": m.role, "content": m.content} for m in req_messages]
+    history_len = len(history)
+    return history + [{"role": m.role, "content": m.content} for m in req_messages], history_len
 
 
 def _persist_chat_result(
@@ -324,7 +329,7 @@ async def chat(
     db: Session = Depends(get_db),
 ) -> ChatResponse:
     song = get_user_song(db, current_user, req.song_id)
-    messages = _load_chat_messages(db, song.id, req.messages)
+    messages, history_len = _load_chat_messages(db, song.id, req.messages)
     api_base = _lookup_api_base(db, song.profile_id, req.provider, req.model)
     profile = db.query(Profile).filter(Profile.id == song.profile_id).first()
 
@@ -341,6 +346,7 @@ async def chat(
                 system_prompt=profile.system_prompt_chat if profile else None,
                 max_tokens=req.max_tokens,
                 api_key=req.api_key,
+                history_len=history_len,
             ),
         )
     except HTTPException:
@@ -383,7 +389,7 @@ async def chat_stream(
     db: Session = Depends(get_db),
 ) -> StreamingResponse:
     song = get_user_song(db, current_user, req.song_id)
-    messages = _load_chat_messages(db, song.id, req.messages)
+    messages, history_len = _load_chat_messages(db, song.id, req.messages)
     api_base = _lookup_api_base(db, song.profile_id, req.provider, req.model)
     profile = db.query(Profile).filter(Profile.id == song.profile_id).first()
 
@@ -402,6 +408,7 @@ async def chat_stream(
                 system_prompt=profile.system_prompt_chat if profile else None,
                 max_tokens=req.max_tokens,
                 api_key=req.api_key,
+                history_len=history_len,
             )
             async for kind, text in stream:
                 if await request.is_disconnected():

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -81,6 +81,8 @@ class ProviderConnectionOut(BaseModel):
 class TokenUsage(BaseModel):
     input_tokens: int = 0
     output_tokens: int = 0
+    cache_creation_input_tokens: int | None = None
+    cache_read_input_tokens: int | None = None
 
 
 # --- Parse ---

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -5,32 +5,42 @@ import re
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any, cast
 
-from any_llm import LLMProvider, acompletion, alist_models
+from any_llm import LLMProvider, alist_models, amessages
+from any_llm.types.messages import MessageResponse, MessageStreamEvent
 
 if TYPE_CHECKING:
-    from any_llm.types.completion import ChatCompletion, ChatCompletionChunk
-
     from ..models import Song
     from ..schemas import ProviderInfo
 
 
-def _get_content(response: ChatCompletion) -> str:
-    """Extract text content from a completion response, raising on empty."""
-    content = response.choices[0].message.content
-    if content is None:
-        raise ValueError("LLM returned empty response")
-    return content
+def _get_content(response: MessageResponse) -> str:
+    """Extract text content from a message response, raising on empty."""
+    for block in response.content:
+        if block.type == "text" and block.text:
+            return block.text
+    raise ValueError("LLM returned empty response")
 
 
-def _get_usage(response: ChatCompletion) -> dict[str, int] | None:
-    """Extract token usage from a completion response, if present."""
-    usage = getattr(response, "usage", None)
-    if usage is None:
-        return None
-    return {
-        "input_tokens": getattr(usage, "prompt_tokens", 0) or 0,
-        "output_tokens": getattr(usage, "completion_tokens", 0) or 0,
+def _get_usage(response: MessageResponse) -> dict[str, int | None]:
+    """Extract token usage from a message response."""
+    usage = response.usage
+    result: dict[str, int | None] = {
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
     }
+    if usage.cache_creation_input_tokens is not None:
+        result["cache_creation_input_tokens"] = usage.cache_creation_input_tokens
+    if usage.cache_read_input_tokens is not None:
+        result["cache_read_input_tokens"] = usage.cache_read_input_tokens
+    return result
+
+
+def _get_reasoning(response: MessageResponse) -> str | None:
+    """Extract reasoning/thinking content from a message response."""
+    for block in response.content:
+        if block.type == "thinking" and block.thinking:
+            return block.thinking
+    return None
 
 
 CLEAN_SYSTEM_PROMPT = """You are PorchSongs, a song lyric editing assistant. You are part of the \
@@ -121,6 +131,9 @@ _LOCAL_PROVIDERS = {"ollama", "llamafile", "llamacpp", "lmstudio", "vllm"}
 # Meta-providers that proxy to other providers and should not be directly selectable.
 _HIDDEN_PROVIDERS = {"platform"}
 
+# Providers that support Anthropic-style prompt caching via cache_control.
+_CACHEABLE_PROVIDERS = {"anthropic"}
+
 
 def is_platform_enabled() -> bool:
     """Return True when the Any LLM Platform key is configured."""
@@ -147,6 +160,26 @@ async def get_models(provider: str, api_base: str | None = None) -> list[str]:
     return [m.id if hasattr(m, "id") else str(m) for m in raw]
 
 
+def _add_cache_breakpoint(message: dict[str, Any]) -> dict[str, Any]:
+    """Add an ephemeral cache_control breakpoint to a message's content.
+
+    Converts plain-string content to a content-block list so Anthropic
+    can attach a cache breakpoint. Messages that are already block-lists
+    get the breakpoint appended to the last block.
+    """
+    content = message["content"]
+    if isinstance(content, str):
+        message["content"] = [
+            {"type": "text", "text": content, "cache_control": {"type": "ephemeral"}}
+        ]
+    elif isinstance(content, list) and content:
+        # Add cache_control to the last content block
+        last_block = content[-1]
+        if isinstance(last_block, dict):
+            last_block["cache_control"] = {"type": "ephemeral"}
+    return message
+
+
 def _build_parse_kwargs(
     content: str,
     provider: str,
@@ -164,34 +197,24 @@ def _build_parse_kwargs(
         user_text += f"\n\nUSER INSTRUCTIONS:\n{instruction}"
     user_text += f"\n\nPASTED INPUT:\n{content}"
 
+    from ..config import settings
+
     kwargs: dict[str, Any] = {
         "model": model,
         "provider": provider,
         "messages": [
-            {"role": "system", "content": system_prompt or CLEAN_SYSTEM_PROMPT},
             {"role": "user", "content": user_text},
         ],
+        "system": system_prompt or CLEAN_SYSTEM_PROMPT,
+        "max_tokens": max_tokens if max_tokens is not None else settings.default_max_tokens,
     }
     if api_base:
         kwargs["api_base"] = api_base
     if api_key:
         kwargs["api_key"] = api_key
-    kwargs["reasoning_effort"] = reasoning_effort
-    from ..config import settings
-
-    kwargs["max_tokens"] = max_tokens if max_tokens is not None else settings.default_max_tokens
+    if reasoning_effort:
+        kwargs["reasoning_effort"] = reasoning_effort
     return kwargs
-
-
-def _get_reasoning(response: ChatCompletion) -> str | None:
-    """Extract reasoning content from a completion response, if present."""
-    msg = response.choices[0].message
-    reasoning = getattr(msg, "reasoning", None)
-    if reasoning is not None:
-        reasoning_content = getattr(reasoning, "content", None)
-        if reasoning_content:
-            return str(reasoning_content)
-    return None
 
 
 async def parse_content(
@@ -220,7 +243,7 @@ async def parse_content(
         max_tokens,
         api_key,
     )
-    clean_response = cast("ChatCompletion", await acompletion(**kwargs))
+    clean_response = cast("MessageResponse", await amessages(**kwargs))
     clean_result = _parse_clean_response(_get_content(clean_response), content)
     reasoning = _get_reasoning(clean_response)
     usage = _get_usage(clean_response)
@@ -247,7 +270,8 @@ async def parse_content_stream(
 ) -> AsyncIterator[tuple[str, str]]:
     """Stream parse tokens as ``(type, text)`` tuples.
 
-    Types: ``"token"`` for content, ``"reasoning"`` for reasoning/thinking.
+    Types: ``"token"`` for content, ``"reasoning"`` for reasoning/thinking,
+    ``"usage"`` for final token usage JSON.
     """
     kwargs = _build_parse_kwargs(
         content,
@@ -260,32 +284,40 @@ async def parse_content_stream(
         max_tokens,
         api_key,
     )
-    if provider == "openai":
-        kwargs["stream_options"] = {"include_usage": True}
-    response = cast("AsyncIterator[ChatCompletionChunk]", await acompletion(stream=True, **kwargs))
+    response = cast(
+        "AsyncIterator[MessageStreamEvent]",
+        await amessages(stream=True, **kwargs),
+    )
 
     import json
 
-    async for chunk in response:
-        if not chunk.choices:
-            continue
-        delta = chunk.choices[0].delta
-        if delta:
-            reasoning = getattr(delta, "reasoning", None)
-            if reasoning is not None:
-                reasoning_content = getattr(reasoning, "content", None)
-                if reasoning_content:
-                    yield ("reasoning", str(reasoning_content))
-            if delta.content:
-                yield ("token", delta.content)
+    input_usage: dict[str, int | None] = {}
 
-        # Check for usage in the chunk (sent in the final chunk by most providers)
-        chunk_usage = getattr(chunk, "usage", None)
-        if chunk_usage is not None:
-            usage_data = {
-                "input_tokens": getattr(chunk_usage, "prompt_tokens", 0) or 0,
-                "output_tokens": getattr(chunk_usage, "completion_tokens", 0) or 0,
+    async for event in response:
+        if event.type == "message_start" and event.message:
+            u = event.message.usage
+            input_usage = {
+                "input_tokens": u.input_tokens,
+                "cache_creation_input_tokens": u.cache_creation_input_tokens,
+                "cache_read_input_tokens": u.cache_read_input_tokens,
             }
+        elif event.type == "content_block_delta" and event.delta:
+            delta_type = event.delta.get("type")
+            if delta_type == "text_delta":
+                yield ("token", event.delta["text"])
+            elif delta_type == "thinking_delta":
+                yield ("reasoning", event.delta["thinking"])
+        elif event.type == "message_delta" and event.usage:
+            usage_data: dict[str, int | None] = {
+                "input_tokens": input_usage.get("input_tokens", 0),
+                "output_tokens": event.usage.output_tokens,
+            }
+            cache_create = input_usage.get("cache_creation_input_tokens")
+            cache_read = input_usage.get("cache_read_input_tokens")
+            if cache_create is not None:
+                usage_data["cache_creation_input_tokens"] = cache_create
+            if cache_read is not None:
+                usage_data["cache_read_input_tokens"] = cache_read
             yield ("usage", json.dumps(usage_data))
 
 
@@ -376,12 +408,13 @@ def _build_chat_kwargs(
     system_prompt: str | None = None,
     max_tokens: int | None = None,
     api_key: str | None = None,
+    history_len: int = 0,
 ) -> dict[str, Any]:
     """Build the common kwargs dict for chat LLM calls."""
     system_content = system_prompt or CHAT_SYSTEM_PROMPT
     system_content += "\n\nORIGINAL SONG:\n" + song.original_content
 
-    llm_messages: list[dict[str, Any]] = [{"role": "system", "content": system_content}]
+    llm_messages: list[dict[str, Any]] = []
     for msg in messages:
         content = msg["content"]
         # Skip messages with empty content - LLM providers reject them.
@@ -391,19 +424,30 @@ def _build_chat_kwargs(
             continue
         llm_messages.append({"role": msg["role"], "content": content})
 
+    # Add prompt caching breakpoints for providers that support it.
+    # Mark the last history message so the provider caches everything up to it.
+    if provider in _CACHEABLE_PROVIDERS and history_len > 0 and len(llm_messages) > 1:
+        # history_len is the count of history messages; the last one is at index history_len - 1
+        # (but some may have been skipped due to empty content, so clamp to actual length)
+        cache_idx = min(history_len - 1, len(llm_messages) - 2)
+        if cache_idx >= 0:
+            _add_cache_breakpoint(llm_messages[cache_idx])
+
+    from ..config import settings
+
     kwargs: dict[str, Any] = {
         "model": model,
         "provider": provider,
         "messages": llm_messages,
+        "system": system_content,
+        "max_tokens": max_tokens if max_tokens is not None else settings.default_max_tokens,
     }
     if api_base:
         kwargs["api_base"] = api_base
     if api_key:
         kwargs["api_key"] = api_key
-    kwargs["reasoning_effort"] = reasoning_effort
-    from ..config import settings
-
-    kwargs["max_tokens"] = max_tokens if max_tokens is not None else settings.default_max_tokens
+    if reasoning_effort:
+        kwargs["reasoning_effort"] = reasoning_effort
     return kwargs
 
 
@@ -417,6 +461,7 @@ async def chat_edit_content(
     system_prompt: str | None = None,
     max_tokens: int | None = None,
     api_key: str | None = None,
+    history_len: int = 0,
 ) -> dict[str, Any]:
     """Process a chat-based content edit (non-streaming).
 
@@ -436,8 +481,9 @@ async def chat_edit_content(
         system_prompt,
         max_tokens,
         api_key,
+        history_len=history_len,
     )
-    response = cast("ChatCompletion", await acompletion(**kwargs))
+    response = cast("MessageResponse", await amessages(**kwargs))
 
     raw_response = _get_content(response)
     parsed = _parse_chat_response(raw_response)
@@ -467,6 +513,7 @@ async def chat_edit_content_stream(
     system_prompt: str | None = None,
     max_tokens: int | None = None,
     api_key: str | None = None,
+    history_len: int = 0,
 ) -> AsyncIterator[tuple[str, str]]:
     """Stream a chat-based content edit token by token as ``(type, text)`` tuples.
 
@@ -483,31 +530,40 @@ async def chat_edit_content_stream(
         system_prompt,
         max_tokens,
         api_key,
+        history_len=history_len,
     )
-    if provider == "openai":
-        kwargs["stream_options"] = {"include_usage": True}
-    response = cast("AsyncIterator[ChatCompletionChunk]", await acompletion(stream=True, **kwargs))
+    response = cast(
+        "AsyncIterator[MessageStreamEvent]",
+        await amessages(stream=True, **kwargs),
+    )
 
     import json
 
-    async for chunk in response:
-        if not chunk.choices:
-            continue
-        delta = chunk.choices[0].delta
-        if delta:
-            reasoning = getattr(delta, "reasoning", None)
-            if reasoning is not None:
-                reasoning_content = getattr(reasoning, "content", None)
-                if reasoning_content:
-                    yield ("reasoning", str(reasoning_content))
-            if delta.content:
-                yield ("token", delta.content)
+    input_usage: dict[str, int | None] = {}
 
-        # Check for usage in the chunk (sent in the final chunk by most providers)
-        chunk_usage = getattr(chunk, "usage", None)
-        if chunk_usage is not None:
-            usage_data = {
-                "input_tokens": getattr(chunk_usage, "prompt_tokens", 0) or 0,
-                "output_tokens": getattr(chunk_usage, "completion_tokens", 0) or 0,
+    async for event in response:
+        if event.type == "message_start" and event.message:
+            u = event.message.usage
+            input_usage = {
+                "input_tokens": u.input_tokens,
+                "cache_creation_input_tokens": u.cache_creation_input_tokens,
+                "cache_read_input_tokens": u.cache_read_input_tokens,
             }
+        elif event.type == "content_block_delta" and event.delta:
+            delta_type = event.delta.get("type")
+            if delta_type == "text_delta":
+                yield ("token", event.delta["text"])
+            elif delta_type == "thinking_delta":
+                yield ("reasoning", event.delta["thinking"])
+        elif event.type == "message_delta" and event.usage:
+            usage_data: dict[str, int | None] = {
+                "input_tokens": input_usage.get("input_tokens", 0),
+                "output_tokens": event.usage.output_tokens,
+            }
+            cache_create = input_usage.get("cache_creation_input_tokens")
+            cache_read = input_usage.get("cache_read_input_tokens")
+            if cache_create is not None:
+                usage_data["cache_creation_input_tokens"] = cache_create
+            if cache_read is not None:
+                usage_data["cache_read_input_tokens"] = cache_read
             yield ("usage", json.dumps(usage_data))

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -944,6 +944,10 @@ export interface components {
              * @default 0
              */
             output_tokens: number;
+            /** Cache Creation Input Tokens */
+            cache_creation_input_tokens?: number | null;
+            /** Cache Read Input Tokens */
+            cache_read_input_tokens?: number | null;
         };
         /** ValidationError */
         ValidationError: {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "pydantic-settings==2.7.1",
     "python-dotenv==1.0.1",
     "requests==2.32.3",
-    "any-llm-sdk[all]>=1.12.0",
+    "any-llm-sdk[all]>=1.13.0",
     "fpdf2>=2.8.0",
     "psycopg2-binary>=2.9.9",
     "alembic>=1.14.0",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -501,18 +501,31 @@ def test_list_profile_models_multiple(client: TestClient) -> None:
     assert len(models) == 2
 
 
+def _make_message_resp(content: str) -> MagicMock:
+    """Build a mock object shaped like a MessageResponse."""
+    text_block = MagicMock()
+    text_block.type = "text"
+    text_block.text = content
+    text_block.thinking = None
+
+    usage = MagicMock()
+    usage.input_tokens = 10
+    usage.output_tokens = 20
+    usage.cache_creation_input_tokens = None
+    usage.cache_read_input_tokens = None
+
+    r = MagicMock()
+    r.content = [text_block]
+    r.usage = usage
+    return r
+
+
 def test_parse_uses_env_credentials(client: TestClient) -> None:
-    """POST /parse should call acompletion without api_key (uses env vars)."""
+    """POST /parse should call amessages without api_key (uses env vars)."""
     profile = client.post("/api/profiles", json={}).json()
 
-    def _make_resp(content: str) -> MagicMock:
-        r = MagicMock()
-        r.choices = [MagicMock()]
-        r.choices[0].message.content = content
-        return r
-
-    with patch("app.services.llm_service.acompletion", new_callable=AsyncMock) as mock_ac:
-        mock_ac.return_value = _make_resp(
+    with patch("app.services.llm_service.amessages", new_callable=AsyncMock) as mock_ac:
+        mock_ac.return_value = _make_message_resp(
             "<meta>\nTitle: Hello Song\nArtist: Test Artist\n</meta>\n"
             "<original>\nHello world\n</original>"
         )
@@ -526,7 +539,7 @@ def test_parse_uses_env_credentials(client: TestClient) -> None:
             },
         )
         assert resp.status_code == 200
-        # Verify acompletion was called without api_key
+        # Verify amessages was called without api_key
         assert mock_ac.call_count == 1
         assert "api_key" not in mock_ac.call_args.kwargs
 
@@ -535,14 +548,8 @@ def test_parse_returns_title_artist(client: TestClient) -> None:
     """POST /parse with META section should return title and artist."""
     profile = client.post("/api/profiles", json={}).json()
 
-    def _make_resp(content: str) -> MagicMock:
-        r = MagicMock()
-        r.choices = [MagicMock()]
-        r.choices[0].message.content = content
-        return r
-
-    with patch("app.services.llm_service.acompletion", new_callable=AsyncMock) as mock_ac:
-        mock_ac.return_value = _make_resp(
+    with patch("app.services.llm_service.amessages", new_callable=AsyncMock) as mock_ac:
+        mock_ac.return_value = _make_message_resp(
             "<meta>\nTitle: Wagon Wheel\nArtist: Old Crow Medicine Show\n</meta>\n"
             "<original>\nRock me mama\n</original>"
         )
@@ -566,14 +573,8 @@ def test_parse_unknown_title_artist(client: TestClient) -> None:
     """POST /parse with UNKNOWN in META should return null title/artist."""
     profile = client.post("/api/profiles", json={}).json()
 
-    def _make_resp(content: str) -> MagicMock:
-        r = MagicMock()
-        r.choices = [MagicMock()]
-        r.choices[0].message.content = content
-        return r
-
-    with patch("app.services.llm_service.acompletion", new_callable=AsyncMock) as mock_ac:
-        mock_ac.return_value = _make_resp(
+    with patch("app.services.llm_service.amessages", new_callable=AsyncMock) as mock_ac:
+        mock_ac.return_value = _make_message_resp(
             "<meta>\nTitle: UNKNOWN\nArtist: UNKNOWN\n</meta>\n<original>\nSome lyrics\n</original>"
         )
         resp = client.post(
@@ -630,14 +631,8 @@ def test_parse_missing_tags_fallback(client: TestClient) -> None:
     """When LLM returns no XML tags, original_content should fall back to raw input."""
     profile = client.post("/api/profiles", json={}).json()
 
-    def _make_resp(content: str) -> MagicMock:
-        r = MagicMock()
-        r.choices = [MagicMock()]
-        r.choices[0].message.content = content
-        return r
-
-    with patch("app.services.llm_service.acompletion", new_callable=AsyncMock) as mock_ac:
-        mock_ac.return_value = _make_resp("Just some text without XML tags")
+    with patch("app.services.llm_service.amessages", new_callable=AsyncMock) as mock_ac:
+        mock_ac.return_value = _make_message_resp("Just some text without XML tags")
         resp = client.post(
             "/api/parse",
             json={
@@ -817,14 +812,12 @@ def test_lookup_api_base_prefers_connection(client: TestClient) -> None:
         },
     )
 
-    mock_response = MagicMock()
-    mock_response.choices = [MagicMock()]
-    mock_response.choices[
-        0
-    ].message.content = "<meta>\nTitle: T\nArtist: A\n</meta>\n<original>\nHello\n</original>"
+    mock_response = _make_message_resp(
+        "<meta>\nTitle: T\nArtist: A\n</meta>\n<original>\nHello\n</original>"
+    )
 
     with patch(
-        "app.services.llm_service.acompletion", new_callable=AsyncMock, return_value=mock_response
+        "app.services.llm_service.amessages", new_callable=AsyncMock, return_value=mock_response
     ) as mock_ac:
         resp = client.post(
             "/api/parse",

--- a/tests/test_llm_endpoints.py
+++ b/tests/test_llm_endpoints.py
@@ -1,4 +1,4 @@
-"""Tests for endpoints that call the LLM, using mocked acompletion/list_models."""
+"""Tests for endpoints that call the LLM, using mocked amessages/list_models."""
 
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -6,14 +6,22 @@ from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
 
 
-def _fake_completion_response(content: str) -> MagicMock:
-    """Build a mock object that looks like a ChatCompletion response."""
-    msg = MagicMock()
-    msg.content = content
-    choice = MagicMock()
-    choice.message = msg
+def _fake_message_response(text: str) -> MagicMock:
+    """Build a mock object that looks like a MessageResponse."""
+    text_block = MagicMock()
+    text_block.type = "text"
+    text_block.text = text
+    text_block.thinking = None
+
+    usage = MagicMock()
+    usage.input_tokens = 10
+    usage.output_tokens = 20
+    usage.cache_creation_input_tokens = None
+    usage.cache_read_input_tokens = None
+
     resp = MagicMock()
-    resp.choices = [choice]
+    resp.content = [text_block]
+    resp.usage = usage
     return resp
 
 
@@ -48,8 +56,8 @@ LLM_SETTINGS = {
 # --- POST /api/parse ---
 
 
-@patch("app.services.llm_service.acompletion")
-def test_parse_endpoint(mock_acompletion: MagicMock, client: TestClient) -> None:
+@patch("app.services.llm_service.amessages")
+def test_parse_endpoint(mock_amessages: MagicMock, client: TestClient) -> None:
     profile = client.post(
         "/api/profiles",
         json={
@@ -57,7 +65,7 @@ def test_parse_endpoint(mock_acompletion: MagicMock, client: TestClient) -> None
         },
     ).json()
 
-    mock_acompletion.return_value = _fake_completion_response(
+    mock_amessages.return_value = _fake_message_response(
         "<meta>\nTitle: Test Song\nArtist: Test Artist\n</meta>\n"
         "<original>\nG  Am\nHello world\nDm  G\nGoodbye moon\n</original>"
     )
@@ -77,19 +85,22 @@ def test_parse_endpoint(mock_acompletion: MagicMock, client: TestClient) -> None
     assert data["artist"] == "Test Artist"
 
     # Verify only 1 LLM call (cleanup only, no rewrite)
-    assert mock_acompletion.call_count == 1
-    # The call should NOT contain any profile description
-    call_kwargs = mock_acompletion.call_args_list[0]
-    messages = call_kwargs.kwargs.get("messages") or call_kwargs[1].get("messages")
-    assert not any("Dad in Austin" in m["content"] for m in messages)
+    assert mock_amessages.call_count == 1
+    # System prompt should be passed as a separate 'system' kwarg, not in messages
+    call_kwargs = mock_amessages.call_args.kwargs
+    assert "system" in call_kwargs
+    messages = call_kwargs.get("messages", [])
+    assert not any(
+        m.get("role") == "system" for m in messages
+    ), "system prompt should not be in messages list"
 
 
-@patch("app.services.llm_service.acompletion")
-def test_parse_unknown_title_artist(mock_acompletion: MagicMock, client: TestClient) -> None:
+@patch("app.services.llm_service.amessages")
+def test_parse_unknown_title_artist(mock_amessages: MagicMock, client: TestClient) -> None:
     """Parse with UNKNOWN title/artist should return null."""
     profile = client.post("/api/profiles", json={"name": "Test"}).json()
 
-    mock_acompletion.return_value = _fake_completion_response(
+    mock_amessages.return_value = _fake_message_response(
         "<meta>\nTitle: UNKNOWN\nArtist: UNKNOWN\n</meta>\n"
         "<original>\nOriginal line one\nOriginal line two\n</original>"
     )
@@ -121,11 +132,11 @@ def test_parse_profile_not_found(client: TestClient) -> None:
     assert resp.status_code == 404
 
 
-@patch("app.services.llm_service.acompletion")
-def test_parse_llm_error(mock_acompletion: MagicMock, client: TestClient) -> None:
+@patch("app.services.llm_service.amessages")
+def test_parse_llm_error(mock_amessages: MagicMock, client: TestClient) -> None:
     """LLM throwing an exception should return 502."""
     profile = client.post("/api/profiles", json={"name": "Test"}).json()
-    mock_acompletion.side_effect = RuntimeError("API rate limit exceeded")
+    mock_amessages.side_effect = RuntimeError("API rate limit exceeded")
 
     resp = client.post(
         "/api/parse",
@@ -144,11 +155,11 @@ def test_parse_llm_error(mock_acompletion: MagicMock, client: TestClient) -> Non
 # --- POST /api/chat ---
 
 
-@patch("app.services.llm_service.acompletion")
-def test_chat_endpoint(mock_acompletion: MagicMock, client: TestClient) -> None:
+@patch("app.services.llm_service.amessages")
+def test_chat_endpoint(mock_amessages: MagicMock, client: TestClient) -> None:
     _, song = _make_profile_and_song(client)
 
-    mock_acompletion.return_value = _fake_completion_response(
+    mock_amessages.return_value = _fake_message_response(
         "<content>\nHi there world\nCatch ya moon\n</content>\nI changed 'see ya' to 'catch ya'."
     )
 
@@ -171,12 +182,12 @@ def test_chat_endpoint(mock_acompletion: MagicMock, client: TestClient) -> None:
     assert data["version"] == 2  # bumped from 1
 
 
-@patch("app.services.llm_service.acompletion")
-def test_chat_persists_changes(mock_acompletion: MagicMock, client: TestClient) -> None:
+@patch("app.services.llm_service.amessages")
+def test_chat_persists_changes(mock_amessages: MagicMock, client: TestClient) -> None:
     """Chat edits should be persisted to the song and create a revision."""
     _, song = _make_profile_and_song(client)
 
-    mock_acompletion.return_value = _fake_completion_response(
+    mock_amessages.return_value = _fake_message_response(
         "<content>\nUpdated line one\nUpdated line two\n</content>\nChanged everything."
     )
 
@@ -199,12 +210,12 @@ def test_chat_persists_changes(mock_acompletion: MagicMock, client: TestClient) 
     assert revisions[1]["edit_type"] == "chat"
 
 
-@patch("app.services.llm_service.acompletion")
-def test_chat_persists_messages(mock_acompletion: MagicMock, client: TestClient) -> None:
+@patch("app.services.llm_service.amessages")
+def test_chat_persists_messages(mock_amessages: MagicMock, client: TestClient) -> None:
     """POST /api/chat should create ChatMessage rows for user + assistant."""
     _, song = _make_profile_and_song(client)
 
-    mock_acompletion.return_value = _fake_completion_response(
+    mock_amessages.return_value = _fake_message_response(
         "<content>\nUpdated line one\nUpdated line two\n</content>\nChanged everything."
     )
 
@@ -227,13 +238,13 @@ def test_chat_persists_messages(mock_acompletion: MagicMock, client: TestClient)
     assert msgs[1]["is_note"] is False
 
 
-@patch("app.services.llm_service.acompletion")
-def test_chat_conversational_no_content(mock_acompletion: MagicMock, client: TestClient) -> None:
+@patch("app.services.llm_service.amessages")
+def test_chat_conversational_no_content(mock_amessages: MagicMock, client: TestClient) -> None:
     """When the LLM responds without <content> tags, no version bump or revision is created."""
     _, song = _make_profile_and_song(client)
     original_version = song["current_version"]
 
-    mock_acompletion.return_value = _fake_completion_response(
+    mock_amessages.return_value = _fake_message_response(
         "Sure! The rhyme scheme in verse 2 is ABAB. Want me to change it?"
     )
 
@@ -262,15 +273,15 @@ def test_chat_conversational_no_content(mock_acompletion: MagicMock, client: Tes
     assert len(revisions) == 1  # only the initial revision
 
 
-@patch("app.services.llm_service.acompletion")
-def test_chat_stores_full_raw_response(mock_acompletion: MagicMock, client: TestClient) -> None:
+@patch("app.services.llm_service.amessages")
+def test_chat_stores_full_raw_response(mock_amessages: MagicMock, client: TestClient) -> None:
     """The assistant ChatMessage stored in DB should be the full raw LLM response."""
     _, song = _make_profile_and_song(client)
 
     raw_response = (
         "<content>\nNew line one\nNew line two\n</content>\nI rewrote both lines for clarity."
     )
-    mock_acompletion.return_value = _fake_completion_response(raw_response)
+    mock_amessages.return_value = _fake_message_response(raw_response)
 
     client.post(
         "/api/chat",
@@ -290,15 +301,15 @@ def test_chat_stores_full_raw_response(mock_acompletion: MagicMock, client: Test
     assert "I rewrote both lines" in assistant_msg["content"]
 
 
-@patch("app.services.llm_service.acompletion")
+@patch("app.services.llm_service.amessages")
 def test_chat_conversational_stores_messages(
-    mock_acompletion: MagicMock, client: TestClient
+    mock_amessages: MagicMock, client: TestClient
 ) -> None:
     """Conversational (no-content) responses should still persist chat messages."""
     _, song = _make_profile_and_song(client)
 
     conversational_response = "Great question! I think we could try an AABB scheme instead."
-    mock_acompletion.return_value = _fake_completion_response(conversational_response)
+    mock_amessages.return_value = _fake_message_response(conversational_response)
 
     client.post(
         "/api/chat",
@@ -355,9 +366,9 @@ def test_list_provider_models_failure(mock_list_models: MagicMock, client: TestC
 # --- api_base passthrough tests ---
 
 
-@patch("app.services.llm_service.acompletion")
-def test_parse_passes_api_base(mock_acompletion: MagicMock, client: TestClient) -> None:
-    """When a ProfileModel has api_base set, the parse call should pass it to acompletion."""
+@patch("app.services.llm_service.amessages")
+def test_parse_passes_api_base(mock_amessages: MagicMock, client: TestClient) -> None:
+    """When a ProfileModel has api_base set, the parse call should pass it to amessages."""
     profile = client.post(
         "/api/profiles",
         json={
@@ -375,7 +386,7 @@ def test_parse_passes_api_base(mock_acompletion: MagicMock, client: TestClient) 
         },
     )
 
-    mock_acompletion.return_value = _fake_completion_response(
+    mock_amessages.return_value = _fake_message_response(
         "<meta>\nTitle: UNKNOWN\nArtist: UNKNOWN\n</meta>\n<original>\nHello world\n</original>"
     )
 
@@ -390,13 +401,13 @@ def test_parse_passes_api_base(mock_acompletion: MagicMock, client: TestClient) 
     )
     assert resp.status_code == 200
 
-    assert mock_acompletion.call_count == 1
-    assert mock_acompletion.call_args.kwargs.get("api_base") == "http://localhost:11434"
+    assert mock_amessages.call_count == 1
+    assert mock_amessages.call_args.kwargs.get("api_base") == "http://localhost:11434"
 
 
-@patch("app.services.llm_service.acompletion")
+@patch("app.services.llm_service.amessages")
 def test_parse_no_api_base_when_no_profile_model(
-    mock_acompletion: MagicMock, client: TestClient
+    mock_amessages: MagicMock, client: TestClient
 ) -> None:
     """When no ProfileModel exists, api_base should not be passed."""
     profile = client.post(
@@ -406,7 +417,7 @@ def test_parse_no_api_base_when_no_profile_model(
         },
     ).json()
 
-    mock_acompletion.return_value = _fake_completion_response(
+    mock_amessages.return_value = _fake_message_response(
         "<meta>\nTitle: UNKNOWN\nArtist: UNKNOWN\n</meta>\n<original>\nHello world\n</original>"
     )
 
@@ -420,8 +431,8 @@ def test_parse_no_api_base_when_no_profile_model(
     )
     assert resp.status_code == 200
 
-    assert mock_acompletion.call_count == 1
-    assert "api_base" not in mock_acompletion.call_args.kwargs
+    assert mock_amessages.call_count == 1
+    assert "api_base" not in mock_amessages.call_args.kwargs
 
 
 @patch("app.services.llm_service.alist_models")
@@ -482,8 +493,8 @@ def test_profile_system_prompt_fields_roundtrip(client: TestClient) -> None:
     assert updated["system_prompt_chat"] == "Custom chat prompt"
 
 
-@patch("app.services.llm_service.acompletion")
-def test_parse_uses_custom_system_prompt(mock_acompletion: MagicMock, client: TestClient) -> None:
+@patch("app.services.llm_service.amessages")
+def test_parse_uses_custom_system_prompt(mock_amessages: MagicMock, client: TestClient) -> None:
     """When a profile has a custom parse prompt, it should be used in the LLM call."""
     custom_prompt = "You are a CUSTOM parse assistant."
     profile = client.post(
@@ -494,7 +505,7 @@ def test_parse_uses_custom_system_prompt(mock_acompletion: MagicMock, client: Te
         },
     ).json()
 
-    mock_acompletion.return_value = _fake_completion_response(
+    mock_amessages.return_value = _fake_message_response(
         "<meta>\nTitle: Test\nArtist: Test\n</meta>\n<original>\nHello world\n</original>"
     )
 
@@ -507,14 +518,12 @@ def test_parse_uses_custom_system_prompt(mock_acompletion: MagicMock, client: Te
         },
     )
 
-    messages = mock_acompletion.call_args.kwargs.get("messages") or mock_acompletion.call_args[
-        1
-    ].get("messages")
-    assert messages[0]["content"] == custom_prompt
+    # System prompt is now a separate kwarg, not in messages
+    assert mock_amessages.call_args.kwargs["system"] == custom_prompt
 
 
-@patch("app.services.llm_service.acompletion")
-def test_chat_uses_custom_system_prompt(mock_acompletion: MagicMock, client: TestClient) -> None:
+@patch("app.services.llm_service.amessages")
+def test_chat_uses_custom_system_prompt(mock_amessages: MagicMock, client: TestClient) -> None:
     """When a profile has a custom chat prompt, it should be used in the LLM call."""
     custom_prompt = "You are a CUSTOM chat assistant."
     profile = client.post(
@@ -533,7 +542,7 @@ def test_chat_uses_custom_system_prompt(mock_acompletion: MagicMock, client: Tes
         },
     ).json()
 
-    mock_acompletion.return_value = _fake_completion_response("Just a conversational response.")
+    mock_amessages.return_value = _fake_message_response("Just a conversational response.")
 
     client.post(
         "/api/chat",
@@ -544,24 +553,22 @@ def test_chat_uses_custom_system_prompt(mock_acompletion: MagicMock, client: Tes
         },
     )
 
-    messages = mock_acompletion.call_args.kwargs.get("messages") or mock_acompletion.call_args[
-        1
-    ].get("messages")
-    # The system message should start with the custom prompt (song content is appended)
-    assert messages[0]["content"].startswith(custom_prompt)
+    # The system kwarg should start with the custom prompt (song content is appended)
+    system_arg = mock_amessages.call_args.kwargs["system"]
+    assert system_arg.startswith(custom_prompt)
 
 
 # --- Multimodal (image) content tests ---
 
 
-@patch("app.services.llm_service.acompletion")
+@patch("app.services.llm_service.amessages")
 def test_chat_multimodal_content_passthrough(
-    mock_acompletion: MagicMock, client: TestClient
+    mock_amessages: MagicMock, client: TestClient
 ) -> None:
     """Multimodal content (image + text) should be passed through to the LLM."""
     _, song = _make_profile_and_song(client)
 
-    mock_acompletion.return_value = _fake_completion_response(
+    mock_amessages.return_value = _fake_message_response(
         "I can see the chord chart. Looks like it's in the key of G."
     )
 
@@ -581,9 +588,7 @@ def test_chat_multimodal_content_passthrough(
     assert resp.status_code == 200
 
     # Verify the multimodal content was passed through to the LLM
-    call_messages = mock_acompletion.call_args.kwargs.get("messages") or mock_acompletion.call_args[
-        1
-    ].get("messages")
+    call_messages = mock_amessages.call_args.kwargs.get("messages", [])
     # Last message should have the multimodal content array
     user_msg = call_messages[-1]
     assert user_msg["role"] == "user"
@@ -592,14 +597,14 @@ def test_chat_multimodal_content_passthrough(
     assert user_msg["content"][1]["type"] == "image_url"
 
 
-@patch("app.services.llm_service.acompletion")
+@patch("app.services.llm_service.amessages")
 def test_chat_multimodal_display_text_only(
-    mock_acompletion: MagicMock, client: TestClient
+    mock_amessages: MagicMock, client: TestClient
 ) -> None:
     """Messages endpoint returns text-only display content for multimodal messages."""
     _, song = _make_profile_and_song(client)
 
-    mock_acompletion.return_value = _fake_completion_response("I can see the chord chart.")
+    mock_amessages.return_value = _fake_message_response("I can see the chord chart.")
 
     multimodal_content = [
         {"type": "text", "text": "Describe this chord chart"},
@@ -623,12 +628,12 @@ def test_chat_multimodal_display_text_only(
     assert "base64" not in msgs[0]["content"]
 
 
-@patch("app.services.llm_service.acompletion")
-def test_chat_plain_string_still_works(mock_acompletion: MagicMock, client: TestClient) -> None:
+@patch("app.services.llm_service.amessages")
+def test_chat_plain_string_still_works(mock_amessages: MagicMock, client: TestClient) -> None:
     """Plain string content should still work after the multimodal change."""
     _, song = _make_profile_and_song(client)
 
-    mock_acompletion.return_value = _fake_completion_response("Sure, here's some feedback.")
+    mock_amessages.return_value = _fake_message_response("Sure, here's some feedback.")
 
     resp = client.post(
         "/api/chat",
@@ -644,14 +649,14 @@ def test_chat_plain_string_still_works(mock_acompletion: MagicMock, client: Test
     assert msgs[0]["content"] == "Give me feedback"
 
 
-@patch("app.services.llm_service.acompletion")
+@patch("app.services.llm_service.amessages")
 def test_chat_image_only_displays_placeholder(
-    mock_acompletion: MagicMock, client: TestClient
+    mock_amessages: MagicMock, client: TestClient
 ) -> None:
     """Image-only messages display as '[Image]' but full content is preserved for LLM."""
     _, song = _make_profile_and_song(client)
 
-    mock_acompletion.return_value = _fake_completion_response("I can see the image.")
+    mock_amessages.return_value = _fake_message_response("I can see the image.")
 
     image_only_content = [
         {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
@@ -674,14 +679,14 @@ def test_chat_image_only_displays_placeholder(
     assert msgs[0]["content"] == "[Image]"
 
 
-@patch("app.services.llm_service.acompletion")
+@patch("app.services.llm_service.amessages")
 def test_chat_after_image_preserves_multimodal_for_llm(
-    mock_acompletion: MagicMock, client: TestClient
+    mock_amessages: MagicMock, client: TestClient
 ) -> None:
     """Follow-up chat loads the full multimodal content (including image) for the LLM."""
     _, song = _make_profile_and_song(client)
 
-    mock_acompletion.return_value = _fake_completion_response("I can see the image.")
+    mock_amessages.return_value = _fake_message_response("I can see the image.")
 
     image_content = [
         {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
@@ -698,7 +703,7 @@ def test_chat_after_image_preserves_multimodal_for_llm(
     )
 
     # Second chat: text follow-up
-    mock_acompletion.return_value = _fake_completion_response("Here are some suggestions.")
+    mock_amessages.return_value = _fake_message_response("Here are some suggestions.")
 
     resp = client.post(
         "/api/chat",
@@ -711,13 +716,182 @@ def test_chat_after_image_preserves_multimodal_for_llm(
     assert resp.status_code == 200
 
     # Verify the LLM received the full multimodal content from history, not a placeholder
-    call_messages = (
-        mock_acompletion.call_args.kwargs.get("messages")
-        or mock_acompletion.call_args[1].get("messages")
-    )
+    call_messages = mock_amessages.call_args.kwargs.get("messages", [])
     user_msgs = [m for m in call_messages if m["role"] == "user"]
     # First user message should be the deserialized multimodal content
     assert isinstance(user_msgs[0]["content"], list)
     assert user_msgs[0]["content"][0]["type"] == "image_url"
     # Second user message is plain text
     assert user_msgs[1]["content"] == "Now improve the chorus"
+
+
+# --- Prompt caching tests ---
+
+
+@patch("app.services.llm_service.amessages")
+def test_chat_anthropic_adds_cache_breakpoint(
+    mock_amessages: MagicMock, client: TestClient
+) -> None:
+    """For anthropic provider, history messages should get cache breakpoints."""
+    _, song = _make_profile_and_song(client)
+
+    # First chat: builds history
+    mock_amessages.return_value = _fake_message_response("First response.")
+    client.post(
+        "/api/chat",
+        json={
+            "song_id": song["id"],
+            "messages": [{"role": "user", "content": "First question"}],
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-20250514",
+        },
+    )
+
+    # Second chat: should add cache breakpoint to last history message
+    mock_amessages.return_value = _fake_message_response("Second response.")
+    client.post(
+        "/api/chat",
+        json={
+            "song_id": song["id"],
+            "messages": [{"role": "user", "content": "Second question"}],
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-20250514",
+        },
+    )
+
+    call_messages = mock_amessages.call_args.kwargs.get("messages", [])
+    # The last history message (assistant's first response) should have cache_control
+    # History is [user1, assistant1], new is [user2]
+    # assistant1 is at index 1, and should have cache breakpoint
+    history_assistant_msg = call_messages[1]
+    assert history_assistant_msg["role"] == "assistant"
+    content = history_assistant_msg["content"]
+    # Content should be converted to block format with cache_control
+    assert isinstance(content, list)
+    assert content[0].get("cache_control") == {"type": "ephemeral"}
+
+
+@patch("app.services.llm_service.amessages")
+def test_chat_non_anthropic_no_cache_breakpoint(
+    mock_amessages: MagicMock, client: TestClient
+) -> None:
+    """For non-anthropic providers, no cache breakpoints should be added."""
+    _, song = _make_profile_and_song(client)
+
+    # First chat: builds history
+    mock_amessages.return_value = _fake_message_response("First response.")
+    client.post(
+        "/api/chat",
+        json={
+            "song_id": song["id"],
+            "messages": [{"role": "user", "content": "First question"}],
+            **LLM_SETTINGS,
+        },
+    )
+
+    # Second chat: no cache breakpoints for openai
+    mock_amessages.return_value = _fake_message_response("Second response.")
+    client.post(
+        "/api/chat",
+        json={
+            "song_id": song["id"],
+            "messages": [{"role": "user", "content": "Second question"}],
+            **LLM_SETTINGS,
+        },
+    )
+
+    call_messages = mock_amessages.call_args.kwargs.get("messages", [])
+    # No message should have cache_control
+    for msg in call_messages:
+        content = msg["content"]
+        if isinstance(content, str):
+            continue  # plain string, no cache_control possible
+        if isinstance(content, list):
+            for block in content:
+                assert "cache_control" not in block
+
+
+# --- Usage with cache metrics ---
+
+
+@patch("app.services.llm_service.amessages")
+def test_parse_returns_cache_usage(mock_amessages: MagicMock, client: TestClient) -> None:
+    """Parse endpoint should return cache token metrics when present."""
+    profile = client.post("/api/profiles", json={"name": "Test"}).json()
+
+    resp_mock = _fake_message_response(
+        "<meta>\nTitle: Test\nArtist: Test\n</meta>\n<original>\nHello\n</original>"
+    )
+    resp_mock.usage.cache_creation_input_tokens = 100
+    resp_mock.usage.cache_read_input_tokens = 50
+    mock_amessages.return_value = resp_mock
+
+    resp = client.post(
+        "/api/parse",
+        json={
+            "profile_id": profile["id"],
+            "content": "Hello",
+            **LLM_SETTINGS,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["usage"]["cache_creation_input_tokens"] == 100
+    assert data["usage"]["cache_read_input_tokens"] == 50
+
+
+# --- Messages API format tests ---
+
+
+@patch("app.services.llm_service.amessages")
+def test_parse_uses_system_parameter(mock_amessages: MagicMock, client: TestClient) -> None:
+    """Parse should use the 'system' parameter instead of a system message."""
+    profile = client.post("/api/profiles", json={"name": "Test"}).json()
+
+    mock_amessages.return_value = _fake_message_response(
+        "<meta>\nTitle: T\nArtist: A\n</meta>\n<original>\nHello\n</original>"
+    )
+
+    client.post(
+        "/api/parse",
+        json={
+            "profile_id": profile["id"],
+            "content": "Hello",
+            **LLM_SETTINGS,
+        },
+    )
+
+    call_kwargs = mock_amessages.call_args.kwargs
+    # System prompt should be a separate parameter
+    assert "system" in call_kwargs
+    assert "PorchSongs" in call_kwargs["system"]
+    # Messages should only contain user messages, no system role
+    messages = call_kwargs["messages"]
+    assert all(m["role"] != "system" for m in messages)
+    assert messages[0]["role"] == "user"
+
+
+@patch("app.services.llm_service.amessages")
+def test_chat_uses_system_parameter(mock_amessages: MagicMock, client: TestClient) -> None:
+    """Chat should use the 'system' parameter with song content appended."""
+    _, song = _make_profile_and_song(client)
+
+    mock_amessages.return_value = _fake_message_response("Got it.")
+
+    client.post(
+        "/api/chat",
+        json={
+            "song_id": song["id"],
+            "messages": [{"role": "user", "content": "Hello"}],
+            **LLM_SETTINGS,
+        },
+    )
+
+    call_kwargs = mock_amessages.call_args.kwargs
+    # System prompt should include PorchSongs prompt + original song
+    assert "system" in call_kwargs
+    assert "PorchSongs" in call_kwargs["system"]
+    assert "Hello world" in call_kwargs["system"]  # original song content
+    # Messages should not contain system role
+    messages = call_kwargs["messages"]
+    assert all(m["role"] != "system" for m in messages)

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -79,16 +79,17 @@ def test_build_chat_kwargs_system_prompt() -> None:
     ]
     kwargs = _build_chat_kwargs(song, messages, "openai", "gpt-4o")  # type: ignore[arg-type]
 
-    llm_messages: list[dict[str, Any]] = kwargs["messages"]
-    system_msg = llm_messages[0]
-    assert system_msg["role"] == "system"
-    assert "ORIGINAL SONG" in system_msg["content"]
-    assert song.original_content in system_msg["content"]
-    assert "EDITED SONG" not in system_msg["content"]
+    # System prompt is now a separate 'system' parameter, not in messages list
+    system_content = kwargs["system"]
+    assert "ORIGINAL SONG" in system_content
+    assert song.original_content in system_content
+    assert "EDITED SONG" not in system_content
 
-    # User/assistant messages passed through unchanged
-    assert llm_messages[1] == {"role": "user", "content": "make it sadder"}
-    assert llm_messages[2] == {"role": "assistant", "content": "ok"}
+    # Messages should only contain user/assistant messages, no system role
+    llm_messages: list[dict[str, Any]] = kwargs["messages"]
+    assert all(m["role"] != "system" for m in llm_messages)
+    assert llm_messages[0] == {"role": "user", "content": "make it sadder"}
+    assert llm_messages[1] == {"role": "assistant", "content": "ok"}
 
 
 def test_build_chat_kwargs_reasoning_effort_off() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -213,9 +213,10 @@ wheels = [
 
 [[package]]
 name = "any-llm-sdk"
-version = "1.12.1"
+version = "1.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anthropic" },
     { name = "httpx" },
     { name = "openai" },
     { name = "openresponses-types" },
@@ -223,9 +224,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/d5/21ef27d031b72f0054ba0015a66cc1f10cda9410e4a3acb6e795d848ad0d/any_llm_sdk-1.12.1.tar.gz", hash = "sha256:76e043fcaa56fccfb375a908511869dc7dbf393dd97a82d06bb764d8201724e8", size = 152078, upload-time = "2026-03-18T13:13:01.735Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/4b/dea4eeeb5e4e3e55fa6b37a7ec033a18a2527aabf565bd598071d6308fbd/any_llm_sdk-1.13.0.tar.gz", hash = "sha256:967c5f4dd099f5f6cc9673f2888d5550f6e821d25341d31133a05741c1ce903e", size = 153753, upload-time = "2026-03-23T10:27:29.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/cf/b8bf1ca1831c18438e117e29da85a58aee3a6a4cb0499e2bd0c0218fccd2/any_llm_sdk-1.12.1-py3-none-any.whl", hash = "sha256:2461eb53995b482499f70d020069e9e22ae5a97c1f7a105d74c33cb620621b09", size = 213698, upload-time = "2026-03-18T13:12:59.896Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a1/0106667efdf870595981a0fc3e807675d1f8ded8dc8c20e936e6c42bcd95/any_llm_sdk-1.13.0-py3-none-any.whl", hash = "sha256:7e456a843cec249ae1cb3a498aa89df5baff8aa62d76a24718babb3b8a51e495", size = 216557, upload-time = "2026-03-23T10:27:28.306Z" },
 ]
 
 [package.optional-dependencies]
@@ -247,6 +248,7 @@ all = [
     { name = "ollama" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
+    { name = "prometheus-client" },
     { name = "psycopg2-binary" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -2339,7 +2341,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.14.0" },
-    { name = "any-llm-sdk", extras = ["all"], specifier = ">=1.12.0" },
+    { name = "any-llm-sdk", extras = ["all"], specifier = ">=1.13.0" },
     { name = "bcrypt", specifier = ">=4.2.0" },
     { name = "fastapi", specifier = "==0.115.6" },
     { name = "fpdf2", specifier = ">=2.8.0" },
@@ -2376,6 +2378,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Migrate the LLM service layer from any-llm's OpenAI-compatible `acompletion()` to the Anthropic-native `amessages()` API. This is enabled by any-llm-sdk v1.13.0 which now uses re-exported Anthropic types natively.

**Key changes:**
- **System prompt as separate parameter**: Cleaner API. System prompt is now passed via the `system` kwarg instead of being embedded as a system-role message in the messages list.
- **Anthropic prompt caching**: For multi-turn chat with Anthropic models, cache breakpoints (`cache_control: {"type": "ephemeral"}`) are added to the last history message. This caches the conversation history, reducing token costs ~90% for cached content on subsequent turns.
- **Native response types**: Uses `MessageResponse` (content blocks) instead of OpenAI `ChatCompletion` (choices/message). Reasoning extracted from `thinking` content blocks. Streaming uses `MessageStreamEvent` events.
- **Cache usage metrics**: `TokenUsage` schema now includes `cache_creation_input_tokens` and `cache_read_input_tokens` so the frontend can display cache efficiency.
- **Foundation for tool use (#172)**: The `amessages` API natively supports `tools` and `tool_choice` parameters, enabling future agentic workflows.

Bumps `any-llm-sdk` from `>=1.12.0` to `>=1.13.0`.

Refs #172

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Researched the any-llm-sdk v1.13.0 release, analyzed the Anthropic provider internals, and implemented the full migration with prompt caching support.

- [x] I am an AI Agent filling out this form (check box if true)