### PR TITLE
feat: visible New Song button with confirmation dialog

### DIFF
--- a/frontend/src/components/RewriteTab.test.tsx
+++ b/frontend/src/components/RewriteTab.test.tsx
@@ -293,6 +293,125 @@ describe('RewriteTab', () => {
     expect(sampleText.compareDocumentPosition(textarea) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
   });
 
+  describe('New Song button', () => {
+    it('renders in PARSED state', () => {
+      // Load a sample to get into parsed state
+      const props = makeProps();
+      render(<RewriteTab {...props} />);
+
+      fireEvent.click(screen.getByText('When the Saints Go Marching In'));
+
+      // Should show "+ New Song" (desktop) and "+ New" (mobile)
+      expect(screen.getByRole('button', { name: '+ New Song' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '+ New' })).toBeInTheDocument();
+    });
+
+    it('renders in WORKSHOPPING state', () => {
+      const props = makeProps({
+        rewriteResult: {
+          original_content: '[C]Hello [G]World',
+          rewritten_content: '[C]Hello [G]World',
+          changes_summary: 'No changes',
+        },
+        rewriteMeta: { title: 'Test', artist: 'Test' },
+        currentSongId: 1,
+      });
+      render(<RewriteTab {...props} />);
+
+      expect(screen.getByRole('button', { name: '+ New Song' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '+ New' })).toBeInTheDocument();
+    });
+
+    it('does not render in INPUT state', () => {
+      const props = makeProps();
+      render(<RewriteTab {...props} />);
+
+      expect(screen.queryByRole('button', { name: '+ New Song' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: '+ New' })).not.toBeInTheDocument();
+    });
+
+    it('shows confirmation dialog when clicked in WORKSHOPPING state', () => {
+      const props = makeProps({
+        rewriteResult: {
+          original_content: '[C]Hello [G]World',
+          rewritten_content: '[C]Hello [G]World',
+          changes_summary: 'No changes',
+        },
+        rewriteMeta: { title: 'Test', artist: 'Test' },
+        currentSongId: 1,
+      });
+      render(<RewriteTab {...props} />);
+
+      fireEvent.click(screen.getByRole('button', { name: '+ New Song' }));
+
+      expect(screen.getByText('Start New Song')).toBeInTheDocument();
+      expect(screen.getByText(/Starting a new song will discard your current work/)).toBeInTheDocument();
+    });
+
+    it('calls onNewRewrite(null, null) when confirmation dialog is confirmed', () => {
+      const onNewRewrite = vi.fn();
+      const props = makeProps({
+        rewriteResult: {
+          original_content: '[C]Hello [G]World',
+          rewritten_content: '[C]Hello [G]World',
+          changes_summary: 'No changes',
+        },
+        rewriteMeta: { title: 'Test', artist: 'Test' },
+        currentSongId: 1,
+        onNewRewrite,
+      });
+      render(<RewriteTab {...props} />);
+
+      fireEvent.click(screen.getByRole('button', { name: '+ New Song' }));
+      fireEvent.click(screen.getByRole('button', { name: 'New Song' }));
+
+      expect(onNewRewrite).toHaveBeenCalledWith(null, null);
+    });
+
+    it('does not clear state when confirmation dialog is cancelled', () => {
+      const onNewRewrite = vi.fn();
+      const props = makeProps({
+        rewriteResult: {
+          original_content: '[C]Hello [G]World',
+          rewritten_content: '[C]Hello [G]World',
+          changes_summary: 'No changes',
+        },
+        rewriteMeta: { title: 'Test', artist: 'Test' },
+        currentSongId: 1,
+        onNewRewrite,
+      });
+      render(<RewriteTab {...props} />);
+
+      fireEvent.click(screen.getByRole('button', { name: '+ New Song' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      // onNewRewrite should not have been called (except initial render effects)
+      expect(onNewRewrite).not.toHaveBeenCalledWith(null, null);
+    });
+
+    it('clears directly without dialog in PARSED state with no chat messages', () => {
+      const onNewRewrite = vi.fn();
+      const setChatMessages = vi.fn();
+      const props = makeProps({
+        chatMessages: [],
+        onNewRewrite,
+        setChatMessages,
+      });
+      render(<RewriteTab {...props} />);
+
+      // Load sample to get into parsed state
+      fireEvent.click(screen.getByText('When the Saints Go Marching In'));
+
+      fireEvent.click(screen.getByRole('button', { name: '+ New Song' }));
+
+      // Should not show dialog
+      expect(screen.queryByText('Start New Song')).not.toBeInTheDocument();
+
+      // Should have called onNewRewrite to clear
+      expect(onNewRewrite).toHaveBeenCalledWith(null, null);
+    });
+  });
+
   it('does not revert rewritten content when original content is updated in the same batch (issue #165)', () => {
     // Setup: workshopping state with known content
     const onNewRewrite = vi.fn();

--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -103,6 +103,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
   const [songTitle, setSongTitle] = useState('');
   const [songArtist, setSongArtist] = useState('');
   const [scrapDialogOpen, setScrapDialogOpen] = useState(false);
+  const [newSongDialogOpen, setNewSongDialogOpen] = useState(false);
   const [showOriginal, setShowOriginal] = useState(false);
   const [hasSongs, setHasSongs] = useState(
     () => !!localStorage.getItem(STORAGE_KEYS.HAS_REWRITTEN),
@@ -278,6 +279,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
   }, [rewriteResult, parseResult, parsedContent, profile, songTitle, songArtist, llmSettings, onNewRewrite, onContentUpdated]);
 
   const handleNewSong = () => {
+    parseAbortRef.current?.abort();
     onNewRewrite(null, null);
     setInput('');
     setParseResult(null);
@@ -290,6 +292,14 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
     setSongTitle('');
     setSongArtist('');
     setChatMessages([]);
+  };
+
+  const handleNewSongClick = () => {
+    if (isWorkshopping || (isParsed && chatMessages.length > 0)) {
+      setNewSongDialogOpen(true);
+    } else {
+      handleNewSong();
+    }
   };
 
   const handleScrap = async () => {
@@ -505,33 +515,41 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
               </Button>
             </>
           )}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-7 w-7 text-muted-foreground" aria-label="More actions">
-                &hellip;
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {isParsed && parseResult?.reasoning && (
-                <DropdownMenuItem onClick={() => setParseReasoningExpanded(prev => !prev)}>
-                  {parseReasoningExpanded ? 'Hide thinking' : 'Show thinking'}
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuItem onClick={handleNewSong}>New Song</DropdownMenuItem>
-              {isWorkshopping && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    className="text-danger can-hover:hover:!bg-danger-light"
-                    disabled={!currentSongUuid}
-                    onClick={() => setScrapDialogOpen(true)}
-                  >
-                    Scrap This
+          <Button
+            variant="secondary"
+            className="h-7 px-2.5 text-xs"
+            onClick={handleNewSongClick}
+          >
+            + New
+          </Button>
+          {((isParsed && parseResult?.reasoning) || isWorkshopping) && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-7 w-7 text-muted-foreground" aria-label="More actions">
+                  &hellip;
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {isParsed && parseResult?.reasoning && (
+                  <DropdownMenuItem onClick={() => setParseReasoningExpanded(prev => !prev)}>
+                    {parseReasoningExpanded ? 'Hide thinking' : 'Show thinking'}
                   </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+                )}
+                {isWorkshopping && (
+                  <>
+                    {isParsed && parseResult?.reasoning && <DropdownMenuSeparator />}
+                    <DropdownMenuItem
+                      className="text-danger can-hover:hover:!bg-danger-light"
+                      disabled={!currentSongUuid}
+                      onClick={() => setScrapDialogOpen(true)}
+                    >
+                      Scrap This
+                    </DropdownMenuItem>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
       </div>
     </div>
@@ -692,33 +710,41 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
                   </Button>
                 </>
               )}
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="icon" className="h-7 w-7 text-muted-foreground" aria-label="More actions">
-                    &hellip;
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  {isParsed && parseResult?.reasoning && (
-                    <DropdownMenuItem onClick={() => setParseReasoningExpanded(prev => !prev)}>
-                      {parseReasoningExpanded ? 'Hide thinking' : 'Show thinking'}
-                    </DropdownMenuItem>
-                  )}
-                  <DropdownMenuItem onClick={handleNewSong}>New Song</DropdownMenuItem>
-                  {isWorkshopping && (
-                    <>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        className="text-danger can-hover:hover:!bg-danger-light"
-                        disabled={!currentSongUuid}
-                        onClick={() => setScrapDialogOpen(true)}
-                      >
-                        Scrap This
+              <Button
+                variant="secondary"
+                className="h-7 px-2.5 text-xs"
+                onClick={handleNewSongClick}
+              >
+                + New Song
+              </Button>
+              {((isParsed && parseResult?.reasoning) || isWorkshopping) && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon" className="h-7 w-7 text-muted-foreground" aria-label="More actions">
+                      &hellip;
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {isParsed && parseResult?.reasoning && (
+                      <DropdownMenuItem onClick={() => setParseReasoningExpanded(prev => !prev)}>
+                        {parseReasoningExpanded ? 'Hide thinking' : 'Show thinking'}
                       </DropdownMenuItem>
-                    </>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
+                    )}
+                    {isWorkshopping && (
+                      <>
+                        {isParsed && parseResult?.reasoning && <DropdownMenuSeparator />}
+                        <DropdownMenuItem
+                          className="text-danger can-hover:hover:!bg-danger-light"
+                          disabled={!currentSongUuid}
+                          onClick={() => setScrapDialogOpen(true)}
+                        >
+                          Scrap This
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
             </div>
           </div>
 
@@ -751,28 +777,24 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
                          saveStatus === 'saving' ? 'Saving...' : 'Save'}
                       </Button>
                     )}
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" size="icon" className="h-7 w-7 text-muted-foreground" aria-label="More actions">
-                          &hellip;
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem onClick={handleNewSong}>New Song</DropdownMenuItem>
-                        {isWorkshopping && (
-                          <>
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem
-                              className="text-danger can-hover:hover:!bg-danger-light"
-                              disabled={!currentSongUuid}
-                              onClick={() => setScrapDialogOpen(true)}
-                            >
-                              Scrap This
-                            </DropdownMenuItem>
-                          </>
-                        )}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+                    {isWorkshopping && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon" className="h-7 w-7 text-muted-foreground" aria-label="More actions">
+                            &hellip;
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            className="text-danger can-hover:hover:!bg-danger-light"
+                            disabled={!currentSongUuid}
+                            onClick={() => setScrapDialogOpen(true)}
+                          >
+                            Scrap This
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
                   </>
                 }
               />
@@ -826,6 +848,15 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
         confirmLabel="Scrap"
         variant="destructive"
         onConfirm={handleScrap}
+      />
+
+      <ConfirmDialog
+        open={newSongDialogOpen}
+        onOpenChange={setNewSongDialogOpen}
+        title="Start New Song"
+        description="Starting a new song will discard your current work. Any unsaved changes will be lost."
+        confirmLabel="New Song"
+        onConfirm={handleNewSong}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Closes #175

- **Add prominent "+ New Song" button** to desktop toolbar and "+ New" to mobile toolbar, visible in PARSED and WORKSHOPPING states
- **Add confirmation dialog** when starting a new song with unsaved work (workshopping state, or parsed with chat messages). Skips dialog when minimal work would be lost
- **Fix resource leak**: abort in-flight parse streams when starting a new song
- **Remove "New Song" from all dropdown menus** and conditionally hide empty `...` dropdowns

## Test plan

- [ ] 7 new unit tests covering button visibility, confirmation dialog show/confirm/cancel, and direct-clear behavior
- [ ] All 142 existing frontend tests still pass
- [ ] TypeScript and ESLint checks pass
- [ ] Visual verification: button appears in toolbar in PARSED/WORKSHOPPING states, hidden in INPUT state

🤖 Generated with [Claude Code](https://claude.com/claude-code)