### PR TITLE
feat: display AI credit usage in chat footer via extension

### DIFF
--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -3,7 +3,7 @@ import Markdown from 'react-markdown';
 import { toast } from 'sonner';
 import { cn, stripXmlTags } from '@/lib/utils';
 import api from '@/api';
-import { isQuotaError, QuotaUpgradeLink } from '@/extensions/quota';
+import { isQuotaError, QuotaUpgradeLink, UsageFooter } from '@/extensions/quota';
 import { Card, CardHeader } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -428,16 +428,7 @@ export default function ChatPanel({ songId, messages, setMessages, llmSettings, 
           </div>
         )}
       </div>
-      {(tokenUsage.input_tokens > 0 || tokenUsage.output_tokens > 0) && (
-        <div className="px-4 py-1.5 border-t border-border text-xs text-muted-foreground flex justify-between">
-          <span>
-            Tokens used: {(tokenUsage.input_tokens + tokenUsage.output_tokens).toLocaleString()}
-          </span>
-          <span>
-            {tokenUsage.input_tokens.toLocaleString()} in / {tokenUsage.output_tokens.toLocaleString()} out
-          </span>
-        </div>
-      )}
+      <UsageFooter tokenUsage={tokenUsage} />
       {images.length > 0 && (
         <div className="flex flex-wrap gap-2 px-4 py-2 border-t border-border">
           {images.map((img, idx) => (

--- a/frontend/src/extensions/index.ts
+++ b/frontend/src/extensions/index.ts
@@ -26,4 +26,4 @@ export type {
   CheckoutResponse,
   PortalResponse,
 } from './types';
-export { QuotaBanner, OnboardingBanner, isQuotaError } from './quota';
+export { QuotaBanner, OnboardingBanner, isQuotaError, UsageFooter } from './quota';

--- a/frontend/src/extensions/quota.test.tsx
+++ b/frontend/src/extensions/quota.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { UsageFooter } from '@/extensions/quota';
+
+describe('UsageFooter', () => {
+  it('renders nothing when both input_tokens and output_tokens are 0', () => {
+    const { container } = render(
+      <UsageFooter tokenUsage={{ input_tokens: 0, output_tokens: 0 }} />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders total token count when tokens > 0', () => {
+    render(
+      <UsageFooter tokenUsage={{ input_tokens: 800, output_tokens: 200 }} />,
+    );
+    expect(screen.getByText('Tokens used: 1,000')).toBeInTheDocument();
+  });
+
+  it('shows input/output breakdown', () => {
+    render(
+      <UsageFooter tokenUsage={{ input_tokens: 800, output_tokens: 200 }} />,
+    );
+    expect(screen.getByText('800 in / 200 out')).toBeInTheDocument();
+  });
+
+  it('displays formatted numbers with locale separators', () => {
+    render(
+      <UsageFooter tokenUsage={{ input_tokens: 10000, output_tokens: 2345 }} />,
+    );
+    expect(screen.getByText('Tokens used: 12,345')).toBeInTheDocument();
+    expect(screen.getByText('10,000 in / 2,345 out')).toBeInTheDocument();
+  });
+
+  it('has aria-live="polite" for accessibility', () => {
+    render(
+      <UsageFooter tokenUsage={{ input_tokens: 100, output_tokens: 50 }} />,
+    );
+    const footer = screen.getByText('Tokens used: 150').closest('div');
+    expect(footer).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('renders when only input_tokens > 0', () => {
+    render(
+      <UsageFooter tokenUsage={{ input_tokens: 500, output_tokens: 0 }} />,
+    );
+    expect(screen.getByText('Tokens used: 500')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/extensions/quota.tsx
+++ b/frontend/src/extensions/quota.tsx
@@ -1,5 +1,6 @@
 /** OSS stub: premium overlay replaces this with real quota UI. */
 import type { ReactNode } from 'react';
+import type { TokenUsage } from '@/types';
 
 export function QuotaBanner(): null {
   return null;
@@ -15,4 +16,18 @@ export function QuotaUpgradeLink(_props: { className?: string }): null {
 
 export function isQuotaError(_message: string): boolean {
   return false;
+}
+
+export function UsageFooter({ tokenUsage }: { tokenUsage: TokenUsage }): ReactNode {
+  if (tokenUsage.input_tokens === 0 && tokenUsage.output_tokens === 0) return null;
+  return (
+    <div className="px-4 py-1.5 border-t border-border text-xs text-muted-foreground flex justify-between" aria-live="polite">
+      <span>
+        Tokens used: {(tokenUsage.input_tokens + tokenUsage.output_tokens).toLocaleString()}
+      </span>
+      <span>
+        {tokenUsage.input_tokens.toLocaleString()} in / {tokenUsage.output_tokens.toLocaleString()} out
+      </span>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

- Extract inline token usage footer from `ChatPanel` into a `UsageFooter` extension component in `quota.tsx`
- OSS stub renders the same token display as before ("Tokens used: X,XXX" with in/out breakdown)
- Premium can override `UsageFooter` to show AI credit usage instead of raw tokens
- Add `aria-live="polite"` for screen reader accessibility
- Add 6 unit tests for the new component

Closes #171

Premium follow-up: njbrake/porchsongs-premium#218

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx eslint src/` passes
- [x] `npx vitest run` passes (6 new tests + 10 existing ChatPanel tests)
- [ ] Visual: send a chat message, confirm footer shows "Tokens used: X"

🤖 Generated with [Claude Code](https://claude.com/claude-code)