### PR TITLE
chore: update GitHub org references from njbrake to Brake-Labs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/njbrake/porchsongs
+          images: ghcr.io/brake-labs/porchsongs
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 njbrake
+Copyright (c) 2026 Brake-Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ APP_SECRET='$2b$12$...'
 
 ### Premium plugin
 
-For Google OAuth and other premium features, see the [porchsongs-premium](https://github.com/njbrake/porchsongs-premium) repo.
+For Google OAuth and other premium features, see the [porchsongs-premium](https://github.com/Brake-Labs/porchsongs-premium) repo.
 
 ```bash
 PREMIUM_PLUGIN=porchsongs_premium.plugin

--- a/frontend/src/extensions/routes.tsx
+++ b/frontend/src/extensions/routes.tsx
@@ -19,9 +19,9 @@ export function shouldRedirectRootToApp(_isPremium: boolean): boolean {
 }
 
 export function getFeatureRequestUrl(): string {
-  return 'https://github.com/njbrake/porchsongs/issues/new?title=Feature+request:+&labels=enhancement';
+  return 'https://github.com/Brake-Labs/porchsongs/issues/new?title=Feature+request:+&labels=enhancement';
 }
 
 export function getReportIssueUrl(): string {
-  return 'https://github.com/njbrake/porchsongs/issues/new?title=Bug:+&labels=bug';
+  return 'https://github.com/Brake-Labs/porchsongs/issues/new?title=Bug:+&labels=bug';
 }

--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -70,7 +70,7 @@ describe('AppShell layout', () => {
     renderWithRouter(<AppShell />, { route: '/app/rewrite' });
 
     const link = screen.getByRole('link', { name: 'GitHub' });
-    expect(link).toHaveAttribute('href', 'https://github.com/njbrake/porchsongs');
+    expect(link).toHaveAttribute('href', 'https://github.com/Brake-Labs/porchsongs');
     expect(link).toHaveAttribute('target', '_blank');
     expect(screen.getByText(/Made with/)).toBeInTheDocument();
   });

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -332,7 +332,7 @@ export default function AppShell() {
               Feature request
             </a>
             <a
-              href="https://github.com/njbrake/porchsongs"
+              href="https://github.com/Brake-Labs/porchsongs"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="GitHub"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://porchsongs.ai"
-Repository = "https://github.com/njbrake/porchsongs"
-"Bug Tracker" = "https://github.com/njbrake/porchsongs/issues"
+Repository = "https://github.com/Brake-Labs/porchsongs"
+"Bug Tracker" = "https://github.com/Brake-Labs/porchsongs/issues"
 
 [dependency-groups]
 dev = [

--- a/scripts/upload-pr-video.sh
+++ b/scripts/upload-pr-video.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-REPO="${GITHUB_REPO:-njbrake/porchsongs}"
+REPO="${GITHUB_REPO:-Brake-Labs/porchsongs}"
 PR_NUMBER="${1:?Usage: $0 <pr-number> <video-file>}"
 VIDEO_FILE="${2:?Usage: $0 <pr-number> <video-file>}"
 TAG_NAME="ci-assets"


### PR DESCRIPTION
## Summary
- Updates all references from `njbrake/porchsongs` to `Brake-Labs/porchsongs` across CI workflows, README, LICENSE, pyproject.toml, frontend links, and scripts
- Reflects the repo transfer to the Brake-Labs GitHub organization

## Test plan
- [ ] CI passes (workflows reference correct org)
- [ ] GitHub issue links in the app point to `Brake-Labs/porchsongs`
- [ ] GHCR image path updated in docker workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)