### PR TITLE
fix: keep chat input focused after sending a message

### DIFF
--- a/frontend/src/components/ChatPanel.test.tsx
+++ b/frontend/src/components/ChatPanel.test.tsx
@@ -97,6 +97,24 @@ describe('ChatPanel', () => {
     expect(scrollContainer!.scrollTo).toHaveBeenCalledWith({ top: expect.any(Number), behavior: 'smooth' });
   });
 
+  it('keeps focus on chat input after sending a message', async () => {
+    render(<ChatPanel {...defaults} />);
+    const input = screen.getByPlaceholderText(/Tell the AI/) as HTMLInputElement;
+
+    // Focus the input and type a message
+    input.focus();
+    fireEvent.change(input, { target: { value: 'Make it jazzy' } });
+
+    // Send via Enter key
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    });
+
+    // Input should be cleared and still focused
+    expect(input.value).toBe('');
+    expect(document.activeElement).toBe(input);
+  });
+
   it('rejects images larger than 5 MB with a toast error', async () => {
     render(<ChatPanel {...defaults} />);
     const input = screen.getByPlaceholderText(/Tell the AI/);

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -111,6 +111,7 @@ export default function ChatPanel({ songId, messages, setMessages, llmSettings, 
   const [tokenUsage, setTokenUsage] = useState<TokenUsage>({ input_tokens: 0, output_tokens: 0 });
   const [images, setImages] = useState<AttachedImage[]>([]);
   const [dragging, setDragging] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
   const dragCounterRef = useRef(0);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -259,6 +260,7 @@ export default function ChatPanel({ songId, messages, setMessages, llmSettings, 
     if (!effectiveSongId && onBeforeSend) {
       setInput('');
       setImages([]);
+      inputRef.current?.focus();
       const userMsg: ChatMessage = { role: 'user', content: displayText, images: attachedDataUrls.length > 0 ? attachedDataUrls : undefined };
       setMessages(prev => [...prev, userMsg].slice(-MAX_MESSAGES));
       setSending(true);
@@ -273,6 +275,7 @@ export default function ChatPanel({ songId, messages, setMessages, llmSettings, 
     } else {
       setInput('');
       setImages([]);
+      inputRef.current?.focus();
       const userMsg: ChatMessage = { role: 'user', content: displayText, images: attachedDataUrls.length > 0 ? attachedDataUrls : undefined };
       setMessages(prev => [...prev, userMsg].slice(-MAX_MESSAGES));
     }
@@ -453,6 +456,7 @@ export default function ChatPanel({ songId, messages, setMessages, llmSettings, 
         onDrop={handleDrop}
       >
         <Input
+          ref={inputRef}
           value={input}
           onChange={e => setInput(e.target.value)}
           placeholder={dragging ? 'Drop image here...' : 'Tell the AI how to change the song...'}


### PR DESCRIPTION
## Description

When sending a chat message, the cursor/focus was lost from the chat input, forcing users to re-click the input field after every message. This adds a ref to the chat input and calls `focus()` after clearing the input in `handleSend()`.

Fixes #176

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.6)

- [x] I am an AI Agent filling out this form (check box if true)