### PR TITLE
Fix chat edits not saving (#189)

### DIFF
--- a/frontend/src/components/RewriteTab.test.tsx
+++ b/frontend/src/components/RewriteTab.test.tsx
@@ -224,7 +224,7 @@ describe('RewriteTab', () => {
     });
   });
 
-  it('clears dirty state after chat update (server already persisted)', () => {
+  it('keeps dirty state after chat update so user can save (fixes #189)', () => {
     render(<RewriteTab {...makeProps({
       rewriteResult: {
         original_content: 'original lyrics',
@@ -236,20 +236,14 @@ describe('RewriteTab', () => {
       currentSongUuid: 'test-uuid-42',
     })} />);
 
-    // Edit title to make dirty
-    const titleInput = screen.getAllByLabelText('Song title')[0]!;
-    fireEvent.change(titleInput, { target: { value: 'Dirty Title' } });
-
-    // Buttons should say "Save"
-    expect(screen.getAllByRole('button', { name: 'Save' }).length).toBeGreaterThanOrEqual(1);
-
-    // Simulate chat update (server already persisted)
+    // Simulate chat update
     const chatOnContent = capturedChatPanelProps.onContentUpdated as (s: string) => void;
     act(() => chatOnContent('NEW content from chat'));
 
-    // After chat update, dirty should be cleared -> buttons say "Saved"
-    const savedBtns = screen.getAllByRole('button', { name: 'Saved' });
-    expect(savedBtns.length).toBeGreaterThanOrEqual(1);
+    // After chat update, dirty should be set so user can save
+    const saveBtns = screen.getAllByRole('button', { name: 'Save' });
+    expect(saveBtns.length).toBeGreaterThanOrEqual(1);
+    expect(saveBtns[0]).not.toBeDisabled();
   });
 
   it('Cmd+S triggers save', async () => {

--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -289,7 +289,7 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
     } else {
       onContentUpdated(newContent);
     }
-    setIsDirty(false);
+    setIsDirty(true);
   }, [rewriteResult, parseResult, parsedContent, profile, songTitle, songArtist, llmSettings, onNewRewrite, onContentUpdated]);
 
   const handleNewSong = () => {


### PR DESCRIPTION
## Description

`handleChatUpdate` in `RewriteTab.tsx` unconditionally called `setIsDirty(false)` after every chat content update. This kept the save button permanently disabled ("Saved") after chat edits, preventing users from manually saving. Edits were lost on page refresh.

Changed `setIsDirty(false)` to `setIsDirty(true)` so chat content updates properly mark the song as having unsaved changes, enabling the save button.

Fixes #189

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

**Any Additional AI Details you'd like to share:**
Root cause analysis, fix implementation, and test update all done by Claude Code.

- [x] I am an AI Agent filling out this form (check box if true)