### PR TITLE
Fix PWA background disconnect losing SSE stream

### DIFF
--- a/backend/app/routers/rewrite.py
+++ b/backend/app/routers/rewrite.py
@@ -745,10 +745,13 @@ async def chat_stream(
             yield f"event: error\ndata: {json.dumps(_format_llm_error(e, req.provider))}\n\n"
             return
         finally:
-            if not _completed and stream is not None and accumulated:
+            if not _completed and stream is not None:
                 # Generator abandoned by Starlette (client disconnected between
                 # yields, so the is_disconnected() check never ran).  Spawn a
                 # background task to finish the LLM call and persist the result.
+                # This covers the pre-first-token window too: the LLM call was
+                # initiated, so we must let it complete even if no tokens have
+                # been accumulated yet.
                 logger.info(
                     "Chat stream generator abandoned with %d chars accumulated, "
                     "spawning background task for song %s",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -139,7 +139,6 @@ async function _streamSse<T>(
     let buffer = '';
     let eventType = '';
     let result: T | null = null;
-    let receivedData = false;
 
     for (;;) {
       let readResult: ReadableStreamReadResult<Uint8Array>;
@@ -147,14 +146,14 @@ async function _streamSse<T>(
         readResult = await reader.read();
       } catch {
         // reader.read() rejects when the connection is killed (e.g. mobile
-        // browser suspended the tab). If we already received data, the
-        // backend continues the LLM call and persists the result.
-        if (receivedData) throw new ConnectionLostError();
-        throw new Error('Connection failed');
+        // browser suspended the tab).  Since we have a reader the HTTP
+        // request succeeded, so the backend received it and will continue
+        // the LLM call in a background task — always treat this as a
+        // recoverable connection-lost rather than a hard failure.
+        throw new ConnectionLostError();
       }
       const { done, value } = readResult;
       if (done) break;
-      receivedData = true;
       buffer += decoder.decode(value, { stream: true });
 
       const lines = buffer.split('\n');
@@ -186,8 +185,7 @@ async function _streamSse<T>(
 
     if (!result) {
       // Stream ended without a done event — connection was dropped.
-      if (receivedData) throw new ConnectionLostError();
-      throw new Error('Stream ended without result');
+      throw new ConnectionLostError();
     }
     return result;
   };

--- a/frontend/src/components/ChatPanel.test.tsx
+++ b/frontend/src/components/ChatPanel.test.tsx
@@ -369,6 +369,36 @@ describe('ChatPanel', () => {
     });
   });
 
+  describe('connection lost recovery', () => {
+    it('shows background processing note on ConnectionLostError instead of retry button', async () => {
+      const { ConnectionLostError } = await import('@/api');
+      vi.spyOn(api, 'chatStream').mockRejectedValue(new ConnectionLostError());
+
+      const setMessages = vi.fn();
+      render(<ChatPanel {...defaults} setMessages={setMessages} />);
+      const input = screen.getByPlaceholderText(/How would you like to change/) as HTMLTextAreaElement;
+
+      fireEvent.change(input, { target: { value: 'Make it jazzy' } });
+      await act(async () => {
+        fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+      });
+
+      // Should show "Processing in background..." note, not a retry button
+      const lastCall = setMessages.mock.calls[setMessages.mock.calls.length - 1]!;
+      // setMessages is called with a callback; invoke it to get the resulting messages
+      const result = typeof lastCall[0] === 'function' ? lastCall[0]([{ role: 'user', content: 'Make it jazzy' }]) : lastCall[0];
+      const lastMsg = result[result.length - 1];
+      expect(lastMsg.content).toBe('Processing in background...');
+      expect(lastMsg.isNote).toBe(true);
+      // Retry button should NOT be shown (no Error: prefix)
+      expect(lastMsg.content).not.toMatch(/^Error:/);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+  });
+
   it('restores accumulated token usage from loaded messages', () => {
     const messages: ChatMessage[] = [
       { role: 'user', content: 'Edit 1' },

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -393,6 +393,7 @@ export default function ChatPanel({ songId, profileId, messages, setMessages, ll
         // The backend continues the LLM call and persists the result.
         // The visibility recovery hook will re-fetch when the tab returns.
         pendingQueue.current = [];
+        setLastFailedInput(null);
         setMessages(prev => [...prev.filter(m => !m.pending), { role: 'assistant' as const, content: 'Processing in background...', isNote: true }]);
       } else {
         pendingQueue.current = [];

--- a/tests/test_llm_endpoints.py
+++ b/tests/test_llm_endpoints.py
@@ -1066,6 +1066,55 @@ def test_abandoned_generator_spawns_background_task(
     assert len(revisions) == 2
 
 
+def test_finish_chat_in_background_zero_accumulated(client: TestClient, db_session: Session) -> None:
+    """When a client disconnects before the first LLM token, the background
+    task should still consume the entire stream and persist the result.
+    Regression test for the pre-first-token disconnect bug."""
+    from app.routers.rewrite import _finish_chat_in_background
+
+    _, song_data = _make_profile_and_song(client)
+    song_id = song_data["id"]
+
+    song = db_session.query(Song).filter(Song.id == song_id).first()
+    assert song is not None
+    assert song.current_version == 1
+
+    # Simulate: client disconnected before any tokens arrived.  The entire
+    # LLM response comes through the background task.
+    async def _fake_full_stream() -> AsyncIterator[tuple[str, str]]:
+        yield ("token", "<content>\nBrand new lyrics here")
+        yield ("token", "\n</content>")
+        yield ("token", "\nHere are the new lyrics I wrote.")
+        yield ("usage", '{"input_tokens": 50, "output_tokens": 30}')
+
+    # No tokens were accumulated before disconnect
+    accumulated = ""
+    reasoning = ""
+
+    asyncio.run(
+        _finish_chat_in_background(
+            _fake_full_stream(),
+            accumulated,
+            reasoning,
+            song_id,
+            "gpt-4o-mini",
+        )
+    )
+
+    db_session.expire_all()
+
+    song = db_session.query(Song).filter(Song.id == song_id).first()
+    assert song is not None
+    assert song.current_version == 2
+    assert "Brand new lyrics here" in song.rewritten_content
+
+    revisions = db_session.query(SongRevision).filter(SongRevision.song_id == song_id).all()
+    assert len(revisions) == 2
+
+    messages = db_session.query(ChatMessageModel).filter(ChatMessageModel.song_id == song_id).all()
+    assert any(m.role == "assistant" and m.model == "gpt-4o-mini" for m in messages)
+
+
 # --- Prompt caching tests ---
 
 


### PR DESCRIPTION
## Summary
- **Frontend**: Always throw `ConnectionLostError` when `reader.read()` fails after HTTP connection is established, regardless of whether tokens were received. Previously, pre-first-token disconnects showed a retry button instead of "Processing in background..."
- **Backend**: Spawn background completion task even when no tokens have been accumulated yet. Previously, the `and accumulated` condition in the `finally` block caused the LLM call to be abandoned on pre-first-token disconnect.
- Clear `lastFailedInput` in `ConnectionLostError` handler to prevent stale retry buttons.

## Test plan
- [x] New frontend test: ConnectionLostError shows "Processing in background..." not retry button
- [x] New backend test: `test_finish_chat_in_background_zero_accumulated`
- [x] All 208 frontend unit tests pass
- [x] TypeScript typecheck passes
- [x] ESLint + Ruff lint passes
- [ ] CI (needs PostgreSQL for backend tests)
- [ ] Manual verification on mobile PWA

🤖 Generated with [Claude Code](https://claude.com/claude-code)