### PR TITLE
feat: import songs from a link (Ultimate Guitar and other chord sites)

### DIFF
--- a/backend/app/routers/rewrite.py
+++ b/backend/app/routers/rewrite.py
@@ -38,8 +38,10 @@ from ..schemas import (
     ParseResponse,
     ProvidersResponse,
     TokenUsage,
+    UrlScrapeRequest,
+    UrlScrapeResponse,
 )
-from ..services import llm_service
+from ..services import llm_service, scrape_service
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -417,6 +419,37 @@ async def parse_file(
             status_code=422,
             detail="Unsupported file type. Supported formats: PDF, TXT.",
         )
+
+
+@router.post("/parse/url", response_model=UrlScrapeResponse)
+async def parse_url(
+    req: UrlScrapeRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> UrlScrapeResponse:
+    """Scrape a web page (e.g. an Ultimate Guitar link) for song text.
+
+    Returns the extracted text (with any detected title/artist prepended) so it
+    can flow through the normal parse pipeline, plus the source URL for record.
+    """
+    get_user_profile(db, current_user, req.profile_id)
+
+    try:
+        result = await asyncio.to_thread(scrape_service.scrape_url, req.url)
+    except scrape_service.ScrapeError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from None
+    except Exception:
+        logger.exception("URL scrape failed for %s", req.url)
+        raise HTTPException(
+            status_code=502, detail="Something went wrong fetching that link. Please try again."
+        ) from None
+
+    return UrlScrapeResponse(
+        text=result.text,
+        title=result.title,
+        artist=result.artist,
+        source_url=req.url,
+    )
 
 
 def _deserialize_content(raw: str) -> str | list[dict[str, object]]:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -122,6 +122,18 @@ class FileExtractResponse(BaseModel):
     usage: TokenUsage | None = None  # always None (no LLM call), shape consistency
 
 
+class UrlScrapeRequest(BaseModel):
+    profile_id: int
+    url: str = Field(max_length=2000)
+
+
+class UrlScrapeResponse(BaseModel):
+    text: str
+    title: str | None = None
+    artist: str | None = None
+    source_url: str
+
+
 class ParseResponse(BaseModel):
     original_content: str
     title: str | None = None

--- a/backend/app/services/scrape_service.py
+++ b/backend/app/services/scrape_service.py
@@ -1,0 +1,315 @@
+"""Fetch a web page and extract song lyrics/chords as plain text.
+
+Has dedicated handling for Ultimate Guitar tab pages, which embed their tab
+content as an HTML-escaped JSON blob inside a ``<div class="js-store">``
+element. Falls back to a generic HTML-to-text extraction for other sites.
+
+The extracted text is meant to be fed through the normal parse pipeline
+(``llm_service.parse_content``), which cleans formatting and identifies the
+title/artist. Anything we can determine up front (e.g. Ultimate Guitar's
+structured metadata) is prepended so the parser has a head start.
+"""
+
+import ipaddress
+import json
+import logging
+import re
+import socket
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+# A browser-like User-Agent. Many lyric/chord sites reject the default
+# python-requests UA outright.
+_BROWSER_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+_REQUEST_HEADERS = {
+    "User-Agent": _BROWSER_UA,
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Upgrade-Insecure-Requests": "1",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+}
+_REQUEST_TIMEOUT = 15  # seconds
+_MAX_BYTES = 5 * 1024 * 1024  # cap downloaded HTML at 5 MB
+_MAX_TEXT_CHARS = 100_000  # keep within ParseRequest.content limit
+
+# Browser to impersonate when escalating to curl_cffi (latest Chrome profile).
+_IMPERSONATE_BROWSER = "chrome"
+
+# Signs that a response is a bot-challenge / block page rather than real content.
+# Sites like Ultimate Guitar sit behind Cloudflare, which rejects plain
+# datacenter requests; these markers let us detect that and escalate.
+_BLOCK_STATUS = frozenset({401, 403, 429, 503})
+_BLOCK_BODY_MARKERS = (
+    "Just a moment",
+    "cf-browser-verification",
+    "Checking your browser",
+    "Attention Required",
+    "__cf_chl",
+)
+
+
+class ScrapeError(Exception):
+    """Raised when a page can't be fetched or holds no usable song text.
+
+    ``status_code`` is the HTTP status the API endpoint should surface.
+    """
+
+    def __init__(self, message: str, *, status_code: int = 422) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@dataclass
+class ScrapeResult:
+    text: str
+    title: str | None = None
+    artist: str | None = None
+
+
+def _validate_url(url: str) -> None:
+    """Reject non-http(s) URLs and addresses that resolve to internal hosts.
+
+    This is a basic SSRF guard: the URL is user-supplied and fetched
+    server-side, so we must not let it reach loopback, link-local, or private
+    network ranges (e.g. cloud metadata endpoints).
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ScrapeError("Only http and https links are supported.", status_code=400)
+    host = parsed.hostname
+    if not host:
+        raise ScrapeError("That doesn't look like a valid link.", status_code=400)
+
+    try:
+        addrinfos = socket.getaddrinfo(host, parsed.port or 80, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        raise ScrapeError("Could not resolve that link's address.", status_code=400) from None
+
+    for info in addrinfos:
+        ip = ipaddress.ip_address(info[4][0])
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            raise ScrapeError(
+                "That link points to a private or internal address, which isn't allowed.",
+                status_code=400,
+            )
+
+
+def _read_capped(resp: object) -> bytes:
+    """Read a streaming response body up to ``_MAX_BYTES``."""
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in resp.iter_content(8192):  # type: ignore[attr-defined]
+        chunks.append(chunk)
+        total += len(chunk)
+        if total > _MAX_BYTES:
+            break
+    return b"".join(chunks)
+
+
+def _looks_blocked(status_code: int, body: str) -> bool:
+    """Heuristic: did we get a bot-challenge / block page instead of content?"""
+    if status_code in _BLOCK_STATUS:
+        return True
+    return any(marker in body for marker in _BLOCK_BODY_MARKERS)
+
+
+def _fetch_with_requests(url: str) -> tuple[int, str]:
+    """Plain fetch via requests. Raises ScrapeError on transport failures."""
+    try:
+        resp = requests.get(url, headers=_REQUEST_HEADERS, timeout=_REQUEST_TIMEOUT, stream=True)
+    except requests.Timeout:
+        raise ScrapeError("That link took too long to respond. Try again.") from None
+    except requests.RequestException:
+        raise ScrapeError("Couldn't reach that link. Check the URL and try again.") from None
+    try:
+        body = _read_capped(resp).decode(resp.encoding or "utf-8", errors="replace")
+    finally:
+        resp.close()
+    return resp.status_code, body
+
+
+def _fetch_with_impersonation(url: str) -> tuple[int, str] | None:
+    """Retry via curl_cffi, mimicking a real Chrome TLS/HTTP fingerprint.
+
+    This gets past the passive Cloudflare bot checks that reject plain
+    python-requests (e.g. Ultimate Guitar). Returns ``None`` if curl_cffi is
+    unavailable or the request itself fails, so callers fall back to the
+    original (blocked) response.
+    """
+    try:
+        from curl_cffi import requests as cffi_requests
+    except ImportError:
+        logger.warning("curl_cffi not installed; cannot retry with browser impersonation")
+        return None
+
+    try:
+        resp = cffi_requests.get(
+            url,
+            headers={"Accept-Language": "en-US,en;q=0.9"},
+            timeout=_REQUEST_TIMEOUT,
+            impersonate=_IMPERSONATE_BROWSER,
+            stream=True,
+        )
+    except Exception:
+        logger.exception("Browser-impersonation fetch failed for %s", url)
+        return None
+
+    try:
+        body = _read_capped(resp).decode(resp.encoding or "utf-8", errors="replace")
+    finally:
+        resp.close()
+    return resp.status_code, body
+
+
+def _fetch(url: str) -> str:
+    """Download a page as text, escalating to browser impersonation if blocked.
+
+    Most sites succeed on the cheap requests path. When that looks like a bot
+    block (Cloudflare and friends), we retry once with curl_cffi impersonating
+    Chrome, which is enough for sites like Ultimate Guitar.
+    """
+    status, body = _fetch_with_requests(url)
+
+    if _looks_blocked(status, body):
+        logger.info(
+            "Fetch for %s looks blocked (HTTP %s); retrying with impersonation", url, status
+        )
+        escalated = _fetch_with_impersonation(url)
+        if escalated is not None:
+            status, body = escalated
+
+    if _looks_blocked(status, body):
+        raise ScrapeError(
+            "That site blocked the request. Try copying the chords and pasting them instead."
+        )
+    if status == 404:
+        raise ScrapeError("That link wasn't found (404). Check the URL.")
+    if status >= 400:
+        raise ScrapeError(f"That link returned an error (HTTP {status}).")
+
+    return body
+
+
+def _clean_ug_markup(content: str) -> str:
+    """Strip Ultimate Guitar's ``[ch]``/``[tab]`` markup, leaving plain text.
+
+    UG wraps chords in ``[ch]...[/ch]`` and aligned chord/lyric blocks in
+    ``[tab]...[/tab]``. Removing the markers leaves the chord-over-lyric layout
+    intact, which is what the parser expects.
+    """
+    content = content.replace("\r\n", "\n").replace("\r", "\n")
+    content = re.sub(r"\[/?tab\]", "", content)
+    content = re.sub(r"\[/?ch\]", "", content)
+    return content.strip()
+
+
+def _extract_ultimate_guitar(html_text: str) -> ScrapeResult | None:
+    """Pull tab content and metadata from an Ultimate Guitar page.
+
+    Returns ``None`` if the page isn't an Ultimate Guitar tab page (or its
+    structure has changed), so callers can fall back to generic extraction.
+    """
+    soup = BeautifulSoup(html_text, "html.parser")
+    store_div = soup.find("div", class_="js-store")
+    if store_div is None:
+        return None
+    raw = store_div.get("data-content")
+    if not raw:
+        return None
+
+    try:
+        # BeautifulSoup already HTML-unescapes attribute values, so this is JSON.
+        store = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+    data = store.get("store", {}).get("page", {}).get("data", {})
+    content = data.get("tab_view", {}).get("wiki_tab", {}).get("content")
+    if not content or not isinstance(content, str):
+        return None
+
+    tab = data.get("tab", {})
+    title = tab.get("song_name") or None
+    artist = tab.get("artist_name") or None
+
+    return ScrapeResult(text=_clean_ug_markup(content), title=title, artist=artist)
+
+
+def _normalize_whitespace(text: str) -> str:
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    # Collapse runs of 3+ blank lines down to a single blank line.
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _extract_generic(html_text: str) -> ScrapeResult:
+    """Best-effort plain-text extraction for non-UG pages.
+
+    Chord sites commonly wrap their content in ``<pre>`` tags, so those are
+    preferred; otherwise the full body text is used. The parser does the heavy
+    lifting of turning this into clean chords afterward.
+    """
+    soup = BeautifulSoup(html_text, "html.parser")
+
+    page_title = soup.title.get_text().strip() if soup.title else None
+
+    pres = soup.find_all("pre")
+    if pres:
+        text = "\n\n".join(p.get_text() for p in pres)
+        text = _normalize_whitespace(text)
+        if text:
+            return ScrapeResult(text=text, title=page_title)
+
+    for tag in soup(["script", "style", "noscript", "header", "footer", "nav"]):
+        tag.decompose()
+
+    text = _normalize_whitespace(soup.get_text("\n"))
+    return ScrapeResult(text=text, title=page_title)
+
+
+def scrape_url(url: str) -> ScrapeResult:
+    """Fetch *url* and return extracted song text (and any metadata found).
+
+    Raises :class:`ScrapeError` for invalid/blocked URLs or pages with no
+    usable text. This function is blocking (uses ``requests``); call it via
+    ``asyncio.to_thread`` from async code.
+    """
+    _validate_url(url)
+    html_text = _fetch(url)
+
+    result = _extract_ultimate_guitar(html_text)
+    if result is None:
+        result = _extract_generic(html_text)
+
+    if not result.text.strip():
+        raise ScrapeError("Couldn't find any song text on that page.")
+
+    # Prepend any metadata we found so the parser can identify title/artist
+    # even when the body text doesn't repeat them.
+    header_parts = [p for p in (result.title, result.artist) if p]
+    body = result.text
+    if header_parts:
+        body = " - ".join(header_parts) + "\n\n" + body
+
+    if len(body) > _MAX_TEXT_CHARS:
+        body = body[:_MAX_TEXT_CHARS]
+
+    return ScrapeResult(text=body, title=result.title, artist=result.artist)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -10,6 +10,7 @@ import type {
   SavedModel,
   Song,
   SongRevision,
+  UrlScrapeResult,
 } from '@/types';
 import client, {
   getAccessToken,
@@ -306,6 +307,37 @@ const api = {
       throw new Error(_parseApiError(errBody, `Request failed: ${res.status}`));
     }
     return res.json() as Promise<{ text: string }>;
+  },
+
+  // URL scrape (Ultimate Guitar and other chord sites, no LLM needed)
+  scrapeUrl: async (body: { profile_id: number; url: string }) => {
+    const res = await fetch('/api/parse/url', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ..._getAuthHeaders() },
+      body: JSON.stringify(body),
+    });
+    if (res.status === 401) {
+      const refreshed = await tryRefresh();
+      if (refreshed) {
+        const retry = await fetch('/api/parse/url', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ..._getAuthHeaders() },
+          body: JSON.stringify(body),
+        });
+        if (!retry.ok) {
+          const errBody = await retry.json().catch(() => ({}));
+          throw new Error(_parseApiError(errBody, `Request failed: ${retry.status}`));
+        }
+        return retry.json() as Promise<UrlScrapeResult>;
+      }
+      window.dispatchEvent(new CustomEvent('porchsongs-logout'));
+      throw new Error('Authentication required. Please log in.');
+    }
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}));
+      throw new Error(_parseApiError(errBody, `Request failed: ${res.status}`));
+    }
+    return res.json() as Promise<UrlScrapeResult>;
   },
 
   // Songs

--- a/frontend/src/components/RewriteTab.test.tsx
+++ b/frontend/src/components/RewriteTab.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@/api', () => ({
     parseStream: vi.fn(),
     parseImage: vi.fn().mockResolvedValue({ text: '' }),
     extractFile: vi.fn().mockResolvedValue({ text: '' }),
+    scrapeUrl: vi.fn().mockResolvedValue({ text: '', title: null, artist: null, source_url: '' }),
     listSongs: vi.fn().mockResolvedValue([]),
     updateSong: vi.fn().mockResolvedValue({}),
     saveSong: vi.fn().mockResolvedValue({ id: 99, uuid: 'uuid-99', profile_id: 1 }),
@@ -648,6 +649,104 @@ describe('RewriteTab', () => {
       // Should have called onClearParse to clear parse state in AppShell
       expect(onClearParse).toHaveBeenCalled();
       expect(onNewRewrite).toHaveBeenCalledWith(null, null);
+    });
+  });
+
+  describe('Import from Link', () => {
+    it('renders the Import from Link button in INPUT state', () => {
+      render(<RewriteTab {...makeProps()} />);
+      expect(screen.getByText('Import from Link')).toBeInTheDocument();
+    });
+
+    it('opens a dialog with a URL field when clicked', () => {
+      render(<RewriteTab {...makeProps()} />);
+      fireEvent.click(screen.getByText('Import from Link'));
+      expect(screen.getByText('Import from a link')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText(/ultimate-guitar/)).toBeInTheDocument();
+    });
+
+    it('scrapes the URL and populates the textarea with the returned text', async () => {
+      vi.mocked(api.scrapeUrl).mockResolvedValue({
+        text: 'Im Yours - Jason Mraz\n\nG  D\nWell you done done me',
+        title: 'Im Yours',
+        artist: 'Jason Mraz',
+        source_url: 'https://tabs.ultimate-guitar.com/tab/jason-mraz/im-yours',
+      });
+
+      render(<RewriteTab {...makeProps()} />);
+      fireEvent.click(screen.getByText('Import from Link'));
+
+      const urlInput = screen.getByPlaceholderText(/ultimate-guitar/);
+      fireEvent.change(urlInput, {
+        target: { value: 'https://tabs.ultimate-guitar.com/tab/jason-mraz/im-yours' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Fetch chords' }));
+
+      await waitFor(() => {
+        expect(api.scrapeUrl).toHaveBeenCalledWith({
+          profile_id: 1,
+          url: 'https://tabs.ultimate-guitar.com/tab/jason-mraz/im-yours',
+        });
+      });
+
+      // Dialog closes and the textarea is filled with the scraped text
+      await waitFor(() => {
+        const textarea = screen.getByPlaceholderText(/Paste lyrics/) as HTMLTextAreaElement;
+        expect(textarea.value).toContain('Well you done done me');
+      });
+    });
+
+    it('records source_url on the saved song after importing from a link', async () => {
+      const parseResult = {
+        title: 'Im Yours',
+        artist: 'Jason Mraz',
+        original_content: 'G  D\nWell you done done me',
+      } as ParseResult;
+      const onParse = vi.fn().mockResolvedValue(parseResult);
+      vi.mocked(api.scrapeUrl).mockResolvedValue({
+        text: 'G  D\nWell you done done me',
+        title: 'Im Yours',
+        artist: 'Jason Mraz',
+        source_url: 'https://tabs.ultimate-guitar.com/tab/jason-mraz/im-yours',
+      });
+      vi.mocked(api.saveSong).mockResolvedValue({ id: 7, uuid: 'uuid-7', profile_id: 1 } as never);
+
+      render(<RewriteTab {...makeProps({ onParse })} />);
+
+      // Import from link
+      fireEvent.click(screen.getByText('Import from Link'));
+      fireEvent.change(screen.getByPlaceholderText(/ultimate-guitar/), {
+        target: { value: 'https://tabs.ultimate-guitar.com/tab/jason-mraz/im-yours' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Fetch chords' }));
+
+      await waitFor(() => expect(api.scrapeUrl).toHaveBeenCalled());
+
+      // Then run the import (parse)
+      await waitFor(() => screen.getByText('Import Song'));
+      fireEvent.click(screen.getByText('Import Song'));
+
+      await waitFor(() => {
+        expect(api.saveSong).toHaveBeenCalledWith(expect.objectContaining({
+          source_url: 'https://tabs.ultimate-guitar.com/tab/jason-mraz/im-yours',
+        }));
+      });
+    });
+
+    it('surfaces an error when scraping fails', async () => {
+      const setParseError = vi.fn();
+      vi.mocked(api.scrapeUrl).mockRejectedValue(new Error('That site blocked the request.'));
+
+      render(<RewriteTab {...makeProps({ setParseError })} />);
+      fireEvent.click(screen.getByText('Import from Link'));
+      fireEvent.change(screen.getByPlaceholderText(/ultimate-guitar/), {
+        target: { value: 'https://example.com/song' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Fetch chords' }));
+
+      await waitFor(() => {
+        expect(setParseError).toHaveBeenCalledWith(expect.stringContaining('blocked'));
+      });
     });
   });
 

--- a/frontend/src/components/RewriteTab.tsx
+++ b/frontend/src/components/RewriteTab.tsx
@@ -25,7 +25,10 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogBody,
+  DialogFooter,
 } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 import { QuotaBanner, OnboardingBanner, isQuotaError, QuotaUpgradeLink } from '@/extensions/quota';
 import { SAMPLE_SONGS, sampleToParseResult } from '@/data/sample-songs';
@@ -138,6 +141,12 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const docFileInputRef = useRef<HTMLInputElement>(null);
   const [fileLoading, setFileLoading] = useState(false);
+  const [linkDialogOpen, setLinkDialogOpen] = useState(false);
+  const [linkUrl, setLinkUrl] = useState('');
+  const [linkLoading, setLinkLoading] = useState(false);
+  // Records where imported text came from (e.g. an Ultimate Guitar link) so we
+  // can store it as the song's source_url on save. Cleared after each save.
+  const pendingSourceUrlRef = useRef<string | null>(null);
   const [inputDragging, setInputDragging] = useState(false);
   const inputDragCounterRef = useRef(0);
   const [parseReasoningExpanded, setParseReasoningExpanded] = useState(false);
@@ -337,6 +346,25 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
     }
   };
 
+  const handleScrapeUrl = async () => {
+    const url = linkUrl.trim();
+    if (!url || !profile?.id) return;
+
+    setLinkLoading(true);
+    setParseError(null);
+    try {
+      const result = await api.scrapeUrl({ profile_id: profile.id, url });
+      setInput(result.text);
+      pendingSourceUrlRef.current = result.source_url;
+      setLinkDialogOpen(false);
+      setLinkUrl('');
+    } catch (err) {
+      setParseError('Couldn\'t import from that link: ' + (err as Error).message);
+    } finally {
+      setLinkLoading(false);
+    }
+  };
+
   const handleInputDragEnter = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -419,11 +447,13 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
             profile_id: profile.id,
             title: result.title || null,
             artist: result.artist || null,
+            source_url: pendingSourceUrlRef.current || null,
             original_content: result.original_content,
             rewritten_content: result.original_content,
             llm_provider: llmSettings.provider,
             llm_model: llmSettings.model,
           });
+          pendingSourceUrlRef.current = null;
           localStorage.setItem(STORAGE_KEYS.HAS_REWRITTEN, '1');
           setHasSongs(true);
           savedSongRef.current = { id: song.id, uuid: song.uuid };
@@ -931,6 +961,13 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
                 >
                   {fileLoading ? <><Spinner size="sm" className="mr-1.5" /> Extracting...</> : 'Import from File'}
                 </Button>
+                <Button
+                  variant="secondary"
+                  disabled={!hasProfile}
+                  onClick={() => setLinkDialogOpen(true)}
+                >
+                  Import from Link
+                </Button>
                 <span className="text-xs text-muted-foreground">
                   {parseBlocker ?? shortcutHint}
                 </span>
@@ -1121,6 +1158,41 @@ export default function RewriteTab(directProps?: Partial<RewriteTabProps>) {
           </DialogContent>
         </Dialog>
       )}
+
+      {/* Import from Link dialog */}
+      <Dialog open={linkDialogOpen} onOpenChange={(open) => { setLinkDialogOpen(open); if (!open) setLinkUrl(''); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Import from a link</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <p className="text-sm text-muted-foreground mb-3">
+              Paste a link to a chords page (Ultimate Guitar works best). We&apos;ll fetch the chords so you can clean them up and start workshopping.
+            </p>
+            <Input
+              type="url"
+              value={linkUrl}
+              autoFocus
+              placeholder="https://tabs.ultimate-guitar.com/tab/..."
+              onChange={e => setLinkUrl(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && linkUrl.trim() && !linkLoading) {
+                  e.preventDefault();
+                  handleScrapeUrl();
+                }
+              }}
+            />
+          </DialogBody>
+          <DialogFooter>
+            <Button variant="secondary" onClick={() => setLinkDialogOpen(false)} disabled={linkLoading}>
+              Cancel
+            </Button>
+            <Button onClick={handleScrapeUrl} disabled={!linkUrl.trim() || linkLoading}>
+              {linkLoading ? <><Spinner size="sm" className="mr-1.5" /> Fetching...</> : 'Fetch chords'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <ConfirmDialog
         open={scrapDialogOpen}

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -366,6 +366,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/parse/url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Parse Url
+         * @description Scrape a web page (e.g. an Ultimate Guitar link) for song text.
+         *
+         *     Returns the extracted text (with any detected title/artist prepended) so it
+         *     can flow through the normal parse pipeline, plus the source URL for record.
+         */
+        post: operations["parse_url_api_parse_url_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/chat": {
         parameters: {
             query?: never;
@@ -1034,6 +1057,24 @@ export interface components {
             cache_creation_input_tokens?: number | null;
             /** Cache Read Input Tokens */
             cache_read_input_tokens?: number | null;
+        };
+        /** UrlScrapeRequest */
+        UrlScrapeRequest: {
+            /** Profile Id */
+            profile_id: number;
+            /** Url */
+            url: string;
+        };
+        /** UrlScrapeResponse */
+        UrlScrapeResponse: {
+            /** Text */
+            text: string;
+            /** Title */
+            title?: string | null;
+            /** Artist */
+            artist?: string | null;
+            /** Source Url */
+            source_url: string;
         };
         /** ValidationError */
         ValidationError: {
@@ -1970,6 +2011,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FileExtractResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    parse_url_api_parse_url_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UrlScrapeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UrlScrapeResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -17,6 +17,7 @@ export interface AuthUser {
 }
 export type ChatHistoryRow = components['schemas']['ChatMessageOut'];
 export type ParseResult = components['schemas']['ParseResponse'];
+export type UrlScrapeResult = components['schemas']['UrlScrapeResponse'];
 export type TokenUsage = components['schemas']['TokenUsage'];
 export type ChatResult = components['schemas']['ChatResponse'];
 export type ProviderInfo = components['schemas']['ProviderInfo'];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "pydantic-settings==2.7.1",
     "python-dotenv==1.0.1",
     "requests==2.32.3",
+    "curl_cffi>=0.7.0",
+    "beautifulsoup4>=4.12.0",
     "any-llm-sdk[all]>=1.13.0",
     "fpdf2>=2.8.0",
     "pypdf>=4.0.0",

--- a/tests/test_scrape_service.py
+++ b/tests/test_scrape_service.py
@@ -1,0 +1,238 @@
+"""Tests for the URL scraping service and the /api/parse/url endpoint."""
+
+import html
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.services import scrape_service
+from app.services.scrape_service import ScrapeError, scrape_url
+
+
+def _ug_html(content: str, song_name: str = "Im Yours", artist_name: str = "Jason Mraz") -> str:
+    """Build a minimal Ultimate Guitar page with an escaped js-store blob."""
+    store = {
+        "store": {
+            "page": {
+                "data": {
+                    "tab": {"song_name": song_name, "artist_name": artist_name},
+                    "tab_view": {"wiki_tab": {"content": content}},
+                }
+            }
+        }
+    }
+    escaped = html.escape(json.dumps(store), quote=True)
+    return f'<html><body><div class="js-store" data-content="{escaped}"></div></body></html>'
+
+
+UG_CONTENT = "[tab][ch]G[/ch]      [ch]D[/ch]\nWell you [ch]done[/ch] done me[/tab]\nand I."
+
+
+# --- Ultimate Guitar extraction ---
+
+
+def test_extract_ultimate_guitar_strips_markup() -> None:
+    result = scrape_service._extract_ultimate_guitar(_ug_html(UG_CONTENT))
+    assert result is not None
+    assert result.title == "Im Yours"
+    assert result.artist == "Jason Mraz"
+    # [ch]/[tab] markers removed, chord-over-lyric layout preserved
+    assert "[ch]" not in result.text
+    assert "[tab]" not in result.text
+    assert "G      D" in result.text
+    assert "Well you done done me" in result.text
+
+
+def test_extract_ultimate_guitar_returns_none_for_non_ug() -> None:
+    assert scrape_service._extract_ultimate_guitar("<html><body>nope</body></html>") is None
+
+
+def test_scrape_prepends_title_and_artist() -> None:
+    html_text = _ug_html(UG_CONTENT)
+    with patch.object(scrape_service, "_validate_url"), patch.object(
+        scrape_service, "_fetch", return_value=html_text
+    ):
+        result = scrape_url("https://tabs.ultimate-guitar.com/tab/jason-mraz/im-yours")
+    assert result.text.startswith("Im Yours - Jason Mraz")
+    assert result.title == "Im Yours"
+
+
+# --- Generic extraction ---
+
+
+def test_extract_generic_prefers_pre_blocks() -> None:
+    html_text = "<html><head><title>My Song</title></head><body><pre>C G Am\nlyrics</pre></body></html>"
+    result = scrape_service._extract_generic(html_text)
+    assert "C G Am" in result.text
+    assert "lyrics" in result.text
+    assert result.title == "My Song"
+
+
+def test_extract_generic_strips_scripts() -> None:
+    html_text = "<html><body><script>alert(1)</script><p>hello chords</p></body></html>"
+    result = scrape_service._extract_generic(html_text)
+    assert "alert" not in result.text
+    assert "hello chords" in result.text
+
+
+# --- SSRF / URL validation ---
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://example.com/file",
+        "file:///etc/passwd",
+        "javascript:alert(1)",
+        "not-a-url",
+    ],
+)
+def test_validate_url_rejects_bad_schemes(url: str) -> None:
+    with pytest.raises(ScrapeError):
+        scrape_service._validate_url(url)
+
+
+def test_validate_url_rejects_localhost() -> None:
+    with pytest.raises(ScrapeError) as exc:
+        scrape_service._validate_url("http://localhost:8000/admin")
+    assert exc.value.status_code == 400
+
+
+def test_validate_url_rejects_private_ip() -> None:
+    with pytest.raises(ScrapeError):
+        scrape_service._validate_url("http://169.254.169.254/latest/meta-data/")
+
+
+# --- Fetch escalation (requests -> curl_cffi impersonation) ---
+
+
+@pytest.mark.parametrize(
+    ("status", "body", "expected"),
+    [
+        (200, "<html>real content</html>", False),
+        (403, "", True),
+        (429, "", True),
+        (503, "", True),
+        (200, "<html>Just a moment...</html>", True),
+        (200, "<html>cf-browser-verification</html>", True),
+    ],
+)
+def test_looks_blocked(status: int, body: str, expected: bool) -> None:
+    assert scrape_service._looks_blocked(status, body) is expected
+
+
+def test_fetch_escalates_to_impersonation_when_blocked() -> None:
+    ug_html = _ug_html(UG_CONTENT)
+    with patch.object(
+        scrape_service, "_fetch_with_requests", return_value=(403, "blocked")
+    ) as mock_requests, patch.object(
+        scrape_service, "_fetch_with_impersonation", return_value=(200, ug_html)
+    ) as mock_imp:
+        body = scrape_service._fetch("https://tabs.ultimate-guitar.com/tab/x")
+    mock_requests.assert_called_once()
+    mock_imp.assert_called_once()
+    assert "js-store" in body
+
+
+def test_fetch_skips_impersonation_when_first_attempt_succeeds() -> None:
+    with patch.object(
+        scrape_service, "_fetch_with_requests", return_value=(200, "<html>ok</html>")
+    ), patch.object(scrape_service, "_fetch_with_impersonation") as mock_imp:
+        body = scrape_service._fetch("https://example.com")
+    mock_imp.assert_not_called()
+    assert "ok" in body
+
+
+def test_fetch_raises_block_error_when_still_blocked_after_escalation() -> None:
+    with patch.object(
+        scrape_service, "_fetch_with_requests", return_value=(403, "")
+    ), patch.object(scrape_service, "_fetch_with_impersonation", return_value=None):
+        with pytest.raises(ScrapeError) as exc:
+            scrape_service._fetch("https://tabs.ultimate-guitar.com/tab/x")
+    assert "blocked" in str(exc.value)
+
+
+def test_fetch_raises_not_found_for_404() -> None:
+    with patch.object(scrape_service, "_fetch_with_requests", return_value=(404, "nope")):
+        with pytest.raises(ScrapeError) as exc:
+            scrape_service._fetch("https://example.com/missing")
+    assert "404" in str(exc.value)
+
+
+def test_scrape_via_impersonation_end_to_end() -> None:
+    """A Cloudflare-blocked UG page is recovered via impersonation and parsed."""
+    ug_html = _ug_html(UG_CONTENT)
+    with patch.object(scrape_service, "_validate_url"), patch.object(
+        scrape_service, "_fetch_with_requests", return_value=(403, "blocked")
+    ), patch.object(scrape_service, "_fetch_with_impersonation", return_value=(200, ug_html)):
+        result = scrape_url("https://tabs.ultimate-guitar.com/tab/oasis/wonderwall-chords-27596")
+    assert result.title == "Im Yours"
+    assert "Well you done done me" in result.text
+
+
+# --- Endpoint: POST /api/parse/url ---
+
+
+def _make_profile(client: TestClient) -> dict[str, Any]:
+    return client.post("/api/profiles", json={"name": "Test"}).json()
+
+
+def test_parse_url_endpoint_success(client: TestClient) -> None:
+    profile = _make_profile(client)
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.encoding = "utf-8"
+    fake_resp.iter_content = MagicMock(return_value=[_ug_html(UG_CONTENT).encode()])
+
+    with patch.object(scrape_service, "_validate_url"), patch.object(
+        scrape_service.requests, "get", return_value=fake_resp
+    ):
+        resp = client.post(
+            "/api/parse/url",
+            json={
+                "profile_id": profile["id"],
+                "url": "https://tabs.ultimate-guitar.com/tab/jason-mraz/im-yours",
+            },
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["title"] == "Im Yours"
+    assert body["artist"] == "Jason Mraz"
+    assert "[ch]" not in body["text"]
+    assert body["source_url"].endswith("/im-yours")
+
+
+def test_parse_url_endpoint_profile_not_found(client: TestClient) -> None:
+    resp = client.post(
+        "/api/parse/url",
+        json={"profile_id": 9999, "url": "https://example.com/song"},
+    )
+    assert resp.status_code == 404
+
+
+def test_parse_url_endpoint_maps_scrape_error(client: TestClient) -> None:
+    profile = _make_profile(client)
+    with patch.object(
+        scrape_service,
+        "scrape_url",
+        side_effect=ScrapeError("That site blocked the request.", status_code=422),
+    ):
+        resp = client.post(
+            "/api/parse/url",
+            json={"profile_id": profile["id"], "url": "https://example.com/song"},
+        )
+    assert resp.status_code == 422
+    assert "blocked" in resp.json()["detail"]
+
+
+def test_parse_url_endpoint_rejects_private_address(client: TestClient) -> None:
+    profile = _make_profile(client)
+    resp = client.post(
+        "/api/parse/url",
+        json={"profile_id": profile["id"], "url": "http://localhost:8000/admin"},
+    )
+    assert resp.status_code == 400

--- a/uv.lock
+++ b/uv.lock
@@ -380,6 +380,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.42.51"
 source = { registry = "https://pypi.org/simple" }
@@ -691,6 +704,39 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/97/a538654732974a94ff96c1db621fa464f455c02d4bb7d2652f4edc21d600/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da", size = 4217990, upload-time = "2026-02-10T19:18:25.957Z" },
     { url = "https://files.pythonhosted.org/packages/ae/11/7e500d2dd3ba891197b9efd2da5454b74336d64a7cc419aa7327ab74e5f6/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257", size = 4381252, upload-time = "2026-02-10T19:18:27.496Z" },
     { url = "https://files.pythonhosted.org/packages/bc/58/6b3d24e6b9bc474a2dcdee65dfd1f008867015408a271562e4b690561a4d/cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7", size = 3407605, upload-time = "2026-02-10T19:18:29.233Z" },
+]
+
+[[package]]
+name = "curl-cffi"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "cffi" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/5b/89fcfebd3e5e85134147ac99e9f2b2271165fd4d71984fc65da5f17819b7/curl_cffi-0.15.0.tar.gz", hash = "sha256:ea0c67652bf6893d34ee0f82c944f37e488f6147e9421bef1771cc6545b02ded", size = 196437, upload-time = "2026-04-03T11:12:31.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/42/54ddd442c795f30ce5dd4e49f87ce77505958d3777cd96a91567a3975d2a/curl_cffi-0.15.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bda66404010e9ed743b1b83c20c86f24fe21a9a6873e17479d6e67e29d8ded28", size = 2795267, upload-time = "2026-04-03T11:11:46.48Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2d/3915e238579b3c5a92cead5c79130c3b8d20caaba7616cc4d894650e1d6b/curl_cffi-0.15.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a25620d9bf989c9c029a7d1642999c4c265abb0bad811deb2f77b0b5b2b12e5b", size = 2573544, upload-time = "2026-04-03T11:11:47.951Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b3/9d2f1057749a1b07ba1989db3c1503ce8bed998310bae9aea2c43aa64f20/curl_cffi-0.15.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:582e570aa2586b96ed47cf4a17586b9a3c462cbe43f780487c3dc245c6ef1527", size = 10515369, upload-time = "2026-04-03T11:11:50.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1d/6d10dded5ce3fd8157e558ebd97d09e551b77a62cdc1c31e93d0a633cee5/curl_cffi-0.15.0-cp310-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:838e48212447d9c81364b04707a5c861daf08f8320f9ecb3406a8919d1d5c3b3", size = 10160045, upload-time = "2026-04-03T11:11:52.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc", size = 11090433, upload-time = "2026-04-03T11:11:55.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/0d/78edcc4f71934225db99df68197a107386d59080742fc7bf6bb4d007924f/curl_cffi-0.15.0-cp310-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e5e69eee735f659287e2c84444319d68a1fa68dd37abf228943a4074864283a", size = 10479178, upload-time = "2026-04-03T11:11:57.685Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/84/1e101c1acb1ea2f0b4992f5c3024f596d8e21db0d53540b9d583f673c4e7/curl_cffi-0.15.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa1323950224db24f4c510d010b3affa02196ca853fb424191fa917a513d3f4b", size = 10317051, upload-time = "2026-04-03T11:12:00.295Z" },
+    { url = "https://files.pythonhosted.org/packages/28/42/8ef236b22a6c23d096c85a1dc507efe37bfdfc7a2f8a4b34efb590197369/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:41f80170ba844009273b2660da1964ec31e99e5719d16b3422ada87177e32e13", size = 11299660, upload-time = "2026-04-03T11:12:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/56aeb055d962da87a1be0d74c6c644e251c7e88129b5471dc44ac724e678/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1977e1e12cfb5c11352cbb74acef1bed24eb7d226dab61ca57c168c21acd4d61", size = 11945049, upload-time = "2026-04-03T11:12:05.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8c/2abf99a38d6340d66cf0557e0c750ef3f8883dfc5d450087e01c85861343/curl_cffi-0.15.0-cp310-abi3-win_amd64.whl", hash = "sha256:5a0c1896a0d5a5ac1eb89cd24b008d2b718dd1df6fd2f75451b59ca66e49e572", size = 1661649, upload-time = "2026-04-03T11:12:07.948Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/39/dfd54f2240d3a9b96d77bacc62b97813b35e2aa8ecf5cd5013c683f1ba96/curl_cffi-0.15.0-cp310-abi3-win_arm64.whl", hash = "sha256:a6d57f8389273a3a1f94370473c74897467bcc36af0a17336989780c507fa43d", size = 1410741, upload-time = "2026-04-03T11:12:10.073Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/c24df8a4fc22fa84070dcd94abeba43c15e08cc09e35869565c0bad196fd/curl_cffi-0.15.0-cp313-abi3-android_24_arm64_v8a.whl", hash = "sha256:4682dc38d4336e0eb0b185374db90a760efde63cbea994b4e63f3521d44c4c92", size = 7190427, upload-time = "2026-04-03T11:12:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/132225cb3491d07cc6adcce5fe395e059bde87c68cff1ef87a31c88c7819/curl_cffi-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967ad7355bd8e9586f8c2d02eaa99953747549e7ea4a9b25cd53353e6b67fe6d", size = 2795723, upload-time = "2026-04-03T11:12:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/07/8f/f4f83cd303bef7e8f1749512e5dd157e7e5d08b0a36c8211f9640a2757bf/curl_cffi-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e63539d0d839d0a8c5eacf86229bc68c57803547f35e0db7ee0986328b478c3", size = 2573739, upload-time = "2026-04-03T11:12:15.08Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/643d65c7fc9acd742876aa55c2d7823c438cb7665810acd2e66c9976c4d9/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08c799b89740b9bc49c09fbc3d5907f13ac1f845ca52620507ef9466d4639dd5", size = 10521046, upload-time = "2026-04-03T11:12:17.034Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0b/9b8037113c93f4c5323096163471fa7c35c7676c3f608eeaf1287cd99d58/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b7a92767a888ee90147e18964b396d8435ff42737030d6fb00824ffd6094805", size = 11096115, upload-time = "2026-04-03T11:12:19.694Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/96/fff2fcbd924ef4042e0d67379f751a8a4e3186a91e75e35a4cf218b306ee/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:829cc357061ecb99cc2d406301f609a039e05665322f5c025ec67c38b0dc49ce", size = 11305346, upload-time = "2026-04-03T11:12:22.151Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/304b253a45ab28691c8c5e8cca1e6cbb9cf8e46dfceae4648dd536f75e73/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:408d6f14e346841cd889c2e0962832bb235ba3b6749ebf609f347f747da5e60f", size = 11949834, upload-time = "2026-04-03T11:12:24.986Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/4723d92f08259c707a974aba27a08d0a822b9555e35ca581bf18d055a364/curl_cffi-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b624c7ce087bfda967a013ed0a64702a525444e5b6e97d23534d567ccc6525aa", size = 1702771, upload-time = "2026-04-03T11:12:28.201Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/36bbe06d66fa2b765e4a07199f643a59a9cd1a754207a96335402a9520f4/curl_cffi-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0b6c0543b993996670e9e4b78e305a2d60809d5681903ffb5568e21a387434d3", size = 1466312, upload-time = "2026-04-03T11:12:30.054Z" },
 ]
 
 [[package]]
@@ -2317,6 +2363,8 @@ dependencies = [
     { name = "alembic" },
     { name = "any-llm-sdk", extra = ["all"] },
     { name = "bcrypt" },
+    { name = "beautifulsoup4" },
+    { name = "curl-cffi" },
     { name = "fastapi" },
     { name = "fpdf2" },
     { name = "psycopg2-binary" },
@@ -2344,6 +2392,8 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.14.0" },
     { name = "any-llm-sdk", extras = ["all"], specifier = ">=1.13.0" },
     { name = "bcrypt", specifier = ">=4.2.0" },
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
+    { name = "curl-cffi", specifier = ">=0.7.0" },
     { name = "fastapi", specifier = "==0.115.6" },
     { name = "fpdf2", specifier = ">=2.8.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
@@ -2949,6 +2999,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds an **Import from Link** option: paste a URL to a chords page and PorchSongs scrapes it for the song, then runs it through the existing parse pipeline. Works for Ultimate Guitar and falls back to generic HTML extraction for other sites.

## How it works

**Backend** (`backend/app/services/scrape_service.py`, `POST /api/parse/url`)
- Ultimate Guitar: reads the embedded `js-store` JSON blob, pulls `tab_view.wiki_tab.content` plus the structured `song_name`/`artist_name`, and strips UG's `[ch]`/`[tab]` markup so the chord over lyric layout survives.
- Generic fallback: BeautifulSoup extraction (prefers `<pre>` blocks, strips scripts/nav) for any other chord site.
- **Cloudflare handling:** UG returns 403 to plain server side requests from datacenter IPs. `_fetch` tries `requests` first and, when a response looks bot blocked (status 401/403/429/503 or a Cloudflare challenge marker), escalates once to `curl_cffi` with Chrome impersonation. That presents a real Chrome TLS fingerprint and clears UG's check. No headless browser needed, since the content is in the static HTML, not JS rendered.
- **SSRF guard:** rejects non http(s) schemes and any host resolving to loopback, private, link local, or reserved ranges (e.g. cloud metadata).
- Detected title/artist are prepended to the text so the parser identifies them, and the source URL is saved on the song (`source_url`).

**Frontend** (`RewriteTab.tsx`, `api.ts`)
- An Import from Link button next to Import from Photo / File opens a small dialog with a URL field. On fetch, the scraped text fills the import textarea and flows through the normal Import (parse) step.

## Verification

End to end through the live API against a real UG tab (Wonderwall): plain `requests` was blocked, the service escalated to `curl_cffi`, and it returned HTTP 200 with `title='Wonderwall'`, `artist='Oasis'`, and clean chord over lyric text.

Checks: ruff (lint + format), OpenAPI types fresh, 208 backend tests and 301 frontend tests pass. New coverage: backend extraction / SSRF / endpoint / requests to curl_cffi escalation, and frontend dialog + source_url save flow.

## Notes for reviewers

- Adds the `curl_cffi` dependency (lightweight, no Chromium).
- Cloudflare bypass works from this environment today, but anti bot tuning can change; worth watching real world reliability after deploy. A headless browser tier could slot in later if a site ever throws an active JS challenge.
- **No Playwright `.webm` attached:** Playwright has no installable Chromium for this sandbox (Ubuntu 26.04 ARM64), so the usual UI video could not be recorded here. The UI change is the dialog described above; happy to record a video from an environment where Playwright runs if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)