### PR TITLE
fix: honor explicit column count in performance view regardless of screen width

### DIFF
--- a/frontend/src/lib/performanceLayout.test.ts
+++ b/frontend/src/lib/performanceLayout.test.ts
@@ -67,10 +67,27 @@ describe('solvePerformanceLayout', () => {
     expect(result.numCols).toBe(2);
   });
 
-  it('caps a fixed column preference by what the width can hold', () => {
-    // 4 columns cannot hold a 58-char line on a 350px phone.
+  it('honors a fixed column preference the width cannot fit at the readable floor', () => {
+    // A medium viewport where 3 columns of a 58-char line drop below the 12px
+    // multi-column floor. The old solver clamped this back down to fewer
+    // columns; now we keep the user's choice and shrink the font to fit.
+    const result = solvePerformanceLayout(baseInput({ containerWidth: 900, containerHeight: 960, columnsPref: 3 }));
+    expect(result.numCols).toBe(3);
+    expect(result.fontSize).toBeGreaterThan(0);
+    expect(result.fontSize).toBeLessThanOrEqual(FONT_MAX);
+  });
+
+  it('honors a cramped fixed preference by shrinking the font instead of dropping columns', () => {
+    // 4 columns of a 58-char line on a 350px phone is tiny but it is what the
+    // user explicitly asked for, so we never clip the line off the edge.
     const result = solvePerformanceLayout(baseInput({ containerWidth: 350, containerHeight: 660, columnsPref: 4 }));
-    expect(result.numCols).toBe(1);
+    expect(result.numCols).toBe(4);
+    expect(result.fontSize).toBeGreaterThan(0);
+  });
+
+  it('still caps a fixed column preference by content length', () => {
+    const result = solvePerformanceLayout(baseInput({ maxColsContent: 2, columnsPref: 4 }));
+    expect(result.numCols).toBe(2);
   });
 
   it('caps columns by content length', () => {

--- a/frontend/src/lib/performanceLayout.ts
+++ b/frontend/src/lib/performanceLayout.ts
@@ -142,8 +142,15 @@ interface Candidate {
 /**
  * Evaluate a single column count: the font that fits its width, and (for
  * multi-column) its height, plus whether the whole song fits on screen.
+ *
+ * `honorExplicit` is set when the user picked this column count by hand. In that
+ * mode we never reject the count for being "too narrow": we size the font to fit
+ * the column width so the longest line is not clipped (multi-column can't scroll
+ * sideways), dropping below the readability floor only when the width genuinely
+ * cannot hold the line at the floor. In auto mode the floor is hard, so a
+ * cramped multi-column candidate is simply marked as not fitting and skipped.
  */
-function evaluate(numCols: number, input: SolveInput): Candidate {
+function evaluate(numCols: number, input: SolveInput, honorExplicit = false): Candidate {
   const { containerWidth, containerHeight, charRatio, longestLineLen, totalLines } = input;
   const charsPerLine = Math.max(1, longestLineLen);
 
@@ -159,8 +166,17 @@ function evaluate(numCols: number, input: SolveInput): Candidate {
     return { numCols, fontSize, fitsOnScreen: heightFont >= fontSize };
   }
 
-  // Multi-column must fit both width and height to be worthwhile.
   const fitFont = Math.min(widthFont, heightFont);
+
+  if (honorExplicit) {
+    // Prefer the readable floor, but never let it exceed what the width can
+    // hold or the longest line would clip. Height overflow just scrolls.
+    const floor = Math.min(FONT_MIN_MULTI, widthFont);
+    const fontSize = clamp(fitFont, floor, FONT_MAX);
+    return { numCols, fontSize, fitsOnScreen: fontSize <= fitFont + 0.05 };
+  }
+
+  // Auto multi-column must fit both width and height to be worthwhile.
   return {
     numCols,
     fontSize: clamp(fitFont, FONT_MIN_MULTI, FONT_MAX),
@@ -185,8 +201,10 @@ function maxColumnsByWidth(input: SolveInput, cap: number): number {
  *
  * Auto mode prefers the on-screen layout with the largest font; if nothing fits
  * on screen (long song / narrow viewport) it falls back to a single scrolling
- * column sized to the available width. A fixed `columnsPref` is honored (capped
- * by what the width and content length allow) even if it has to scroll.
+ * column sized to the available width. A fixed `columnsPref` is honored as long
+ * as the content is long enough to split into that many columns; the font
+ * shrinks to whatever fits the resulting column width, even below the
+ * readability floor, rather than silently dropping columns the screen can't fit.
  */
 export function solvePerformanceLayout(input: SolveInput): SolveResult {
   if (input.containerWidth <= 0 || input.containerHeight <= 0) {
@@ -196,9 +214,10 @@ export function solvePerformanceLayout(input: SolveInput): SolveResult {
   const contentCap = Math.max(1, input.maxColsContent);
 
   if (input.columnsPref !== 'auto') {
-    const widthCap = maxColumnsByWidth(input, contentCap);
-    const numCols = clamp(Math.round(input.columnsPref), 1, Math.min(contentCap, Math.max(1, widthCap)));
-    return evaluate(numCols, input);
+    // Honor the user's choice, capped only by what the content length supports.
+    // Width no longer vetoes the column count; the font drops to fit instead.
+    const numCols = clamp(Math.round(input.columnsPref), 1, contentCap);
+    return evaluate(numCols, input, true);
   }
 
   const widthCap = Math.min(contentCap, maxColumnsByWidth(input, contentCap));


### PR DESCRIPTION
## Problem

In the library performance view, picking an explicit **Columns** count (e.g. 3) would silently clamp down to fewer columns when the screen was not wide enough, while the dropdown still showed the number you picked. It read as an arbitrary refusal to add columns.

Root cause: for an explicit preference, `solvePerformanceLayout` ran `maxColumnsByWidth`, which only permitted a column count if the song's longest line fit in a column at the hardcoded 12px `FONT_MIN_MULTI` floor. On a narrower viewport that quietly reduced the count.

## Fix

- An explicit column preference is now capped **only by what the content length supports** (`maxColumnsForContent`); width no longer vetoes the count.
- The font shrinks to fit the resulting column width so the longest line is never clipped (multi-column cannot scroll sideways), dropping below the readability floor only when the width genuinely cannot hold the line at that floor. Height overflow scrolls vertically, as before.
- **Auto mode is unchanged:** its hard 12px floor still skips a cramped multi-column candidate, so the automatic layout never renders unreadably small.

## Tests

`frontend/src/lib/performanceLayout.test.ts`:
- Updated the test that asserted the old clamp-down behavior.
- Added: honoring a count the width can't fit at the floor; honoring a cramped count by shrinking the font instead of dropping columns; confirming the content-length cap still applies.

All `performanceLayout` and `LibraryTab` unit tests pass; typecheck and eslint clean.

## Known related edge (out of scope)

A separate, structure-driven downgrade remains: `splitContentForColumns` returns a single column when it can't find enough section boundaries to split cleanly, even when the count is approved. That is not screen-width related and forcing a mid-section split would break chord/lyric grouping; happy to address separately.

## Note on UI verification

This is pure layout-solver logic (no markup/style change), covered by unit tests. No Playwright `.webm` attached; let me know if you'd like a recorded walkthrough of the live column selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)